### PR TITLE
Add the meta in different RNAseq modules

### DIFF
--- a/bin/count_matrices.R
+++ b/bin/count_matrices.R
@@ -12,13 +12,13 @@ argv <- commandArgs(trailingOnly = TRUE)
 coverage <- as.numeric(argv[1])
 replica <- as.numeric(argv[2])
 group <- as.numeric(argv[3])
-fasta <- argv[4]
+filtered_txfasta <- argv[4]
 filtered_gff3 <- argv[5]
 geneList <- argv[6]
 
 
 #### Load the input files ####
-fasta_annotated = readDNAStringSet(fasta)
+fasta_annotated = readDNAStringSet(filtered_txfasta)
 annotation_data = readRDS(filtered_gff3)
 geneList = readRDS(geneList)
 

--- a/bin/count_matrices.R
+++ b/bin/count_matrices.R
@@ -13,13 +13,13 @@ coverage <- as.numeric(argv[1])
 replica <- as.numeric(argv[2])
 group <- as.numeric(argv[3])
 fasta <- argv[4]
-gff3 <- argv[5]
+filtered_gff3 <- argv[5]
 geneList <- argv[6]
 
 
 #### Load the input files ####
 fasta_annotated = readDNAStringSet(fasta)
-annotation_data = readRDS(gff3)
+annotation_data = readRDS(filtered_gff3)
 geneList = readRDS(geneList)
 
 
@@ -44,59 +44,59 @@ varchange <- c(1, 1.2, 1.5, 2, 0.9, 0.8, 0.6)
 #### Functions to create the expected outputs ####
 
 introduce_var <- function(countmatrix, varget, replica, group){
-  base = countmatrix
-  num_cols = replica * group
-  for (i in 1:num_cols) {
-    countmatrix[,i] <- base[,i] * sample(varget, length(base[,i]), replace = T)
-  }
-  return(countmatrix)
+base = countmatrix
+num_cols = replica * group
+for (i in 1:num_cols) {
+countmatrix[,i] <- base[,i] * sample(varget, length(base[,i]), replace = T)
+}
+return(countmatrix)
 }
 
 introduce_fold_change <- function(countmatrix, index_tx, fold_changes, replica, group){
-  base = countmatrix
-  num_cols = replica * group
-  case_cols = ((replica + 1):num_cols)
-  for (i in case_cols) {
-    countmatrix[index_tx,i] <- sample(fold_changes, length(index_tx), replace = T) * base[index_tx,i]
-  }
-  return(countmatrix)
+base = countmatrix
+num_cols = replica * group
+case_cols = ((replica + 1):num_cols)
+for (i in case_cols) {
+countmatrix[index_tx,i] <- sample(fold_changes, length(index_tx), replace = T) * base[index_tx,i]
+}
+return(countmatrix)
 }
 
 createCountMatrices <- function(basematrix, variancechange, up_changes,
-                                down_changes, genesSelectionList, annotationData,
-                                replica, group) {
-  countMatrices = list()
-  total_samples <- replica * group
-  half_samples <- total_samples / 2
-  control_indices <- seq(1, half_samples)
-  case_indices <- seq(half_samples + 1, total_samples)
+down_changes, genesSelectionList, annotationData,
+replica, group) {
+countMatrices = list()
+total_samples <- replica * group
+half_samples <- total_samples / 2
+control_indices <- seq(1, half_samples)
+case_indices <- seq(half_samples + 1, total_samples)
 
-  for (selectionListName in names(genesSelectionList)){
-    writeLines(paste0("creating count matrix for ", selectionListName))
-    selectionList = genesSelectionList[[selectionListName]]
-    index <- which(annotationData$gene_name %in% selectionList)
-    index_genes_upregulated <- index[1:round(length(index)/2, 0)]
-    index_genes_downregulated <- index[(round(length(index)/2, 0) + 1):length(index)]
-    simulationMatrix <- basematrix
-    simulationMatrix <- introduce_var(simulationMatrix, variancechange, replica, group)
-    simulationMatrix <- introduce_fold_change(simulationMatrix, index_genes_upregulated, up_changes, replica, group)
-    simulationMatrix <- introduce_fold_change(simulationMatrix, index_genes_downregulated, down_changes, replica, group)
-    rownames(simulationMatrix) <- rownames(annotationData)
-    simulationAnnotation <- annotationData[match(selectionList, annotationData$gene_name), ]
-    index_in_simulationMatrix <- match(simulationAnnotation$gene_name, annotationData$gene_name)
-    simulationAnnotation$expMeanCASE <- rowMeans(simulationMatrix[index_in_simulationMatrix, case_indices])
-    simulationAnnotation$expMeanCTRL <- rowMeans(simulationMatrix[index_in_simulationMatrix, control_indices])
-    simulationAnnotation$expLog2FC <- log2(simulationAnnotation$expMeanCASE) - log2(simulationAnnotation$expMeanCTRL)
-    cleanSelectionListName <- gsub(" ", "", selectionListName)
-    saveRDS(simulationMatrix, paste0("countMatrix_", cleanSelectionListName, ".rds"))
-    saveRDS(simulationAnnotation, paste0("expected_", cleanSelectionListName, ".rds"))
-    countMatrices[[selectionListName]] <- simulationMatrix
-    write(selectionListName, file="datasets_simulated.txt", append=TRUE)
-  }
+for (selectionListName in names(genesSelectionList)){
+writeLines(paste0("creating count matrix for ", selectionListName))
+selectionList = genesSelectionList[[selectionListName]]
+index <- which(annotationData$gene_name %in% selectionList)
+index_genes_upregulated <- index[1:round(length(index)/2, 0)]
+index_genes_downregulated <- index[(round(length(index)/2, 0) + 1):length(index)]
+simulationMatrix <- basematrix
+simulationMatrix <- introduce_var(simulationMatrix, variancechange, replica, group)
+simulationMatrix <- introduce_fold_change(simulationMatrix, index_genes_upregulated, up_changes, replica, group)
+simulationMatrix <- introduce_fold_change(simulationMatrix, index_genes_downregulated, down_changes, replica, group)
+rownames(simulationMatrix) <- rownames(annotationData)
+simulationAnnotation <- annotationData[match(selectionList, annotationData$gene_name), ]
+index_in_simulationMatrix <- match(simulationAnnotation$gene_name, annotationData$gene_name)
+simulationAnnotation$expMeanCASE <- rowMeans(simulationMatrix[index_in_simulationMatrix, case_indices])
+simulationAnnotation$expMeanCTRL <- rowMeans(simulationMatrix[index_in_simulationMatrix, control_indices])
+simulationAnnotation$expLog2FC <- log2(simulationAnnotation$expMeanCASE) - log2(simulationAnnotation$expMeanCTRL)
+cleanSelectionListName <- gsub(" ", "", selectionListName)
+saveRDS(simulationMatrix, paste0("countMatrix_", cleanSelectionListName, ".rds"))
+saveRDS(simulationAnnotation, paste0("expected_", cleanSelectionListName, ".rds"))
+countMatrices[[selectionListName]] <- simulationMatrix
+write(selectionListName, file="datasets_simulated.txt", append=TRUE)
+}
 
-  return(countMatrices)
+return(countMatrices)
 }
 
 
 all_simulated_counts <- createCountMatrices(countmat, varchange, up_changes, down_changes,
-                                            geneList, annotation_data, replica, group)
+geneList, annotation_data, replica, group)

--- a/bin/subset_fastatx.R
+++ b/bin/subset_fastatx.R
@@ -77,4 +77,4 @@ cat("\n3) Number of transcripts in FASTA after filtering: ", length(fasta_annota
 
 
 #### Save the filtered FASTA sequences using the specified chromosome of interest ####
-writeXStringSet(fasta_annotated, paste0("gencode_transcripts_noversion_", chromosome_of_interest, ".fasta"), format = "fasta")
+writeXStringSet(fasta_annotated, "gencode_transcripts_noversion.fasta", format = "fasta")

--- a/bin/subset_gff.R
+++ b/bin/subset_gff.R
@@ -256,7 +256,7 @@ significant_results <- list()
 write("\n5) GO enrichment", file = log_file, append = TRUE)
 for (i in 1:nrow(gene_lists)) {
 sig_genes <- gene_lists$unique_genes[[i]]  # Extract the unique genes for the group
-universe <- unique(transcript_data$gene_name)  # Define the universe
+universe <- unique_genes                   # Define the universe
 
 # Perform enrichment for BP, MF, and CC
 ego_bp <- executeGO(sig_genes, universe, "BP")
@@ -265,9 +265,9 @@ ego_cc <- executeGO(sig_genes, universe, "CC")
 
 # Check if the results are NULL, and if so, assign "No enrichment"
 enrichment_results <- list(
-    BP = if (!is.null(ego_bp) && nrow(ego_bp) >= 3) ego_bp else "No enrichment",
-    MF = if (!is.null(ego_mf) && nrow(ego_mf) >= 3) ego_mf else "No enrichment",
-    CC = if (!is.null(ego_cc) && nrow(ego_cc) >= 3) ego_cc else "No enrichment"
+    BP = if (!is.null(ego_bp) && dim(ego_bp)[1] >= 3) ego_bp else "No enrichment",
+    MF = if (!is.null(ego_mf) && dim(ego_mf)[1] >= 3) ego_mf else "No enrichment",
+    CC = if (!is.null(ego_cc) && dim(ego_cc)[1] >= 3) ego_cc else "No enrichment"
 )
 
 # Add the enrichment results to significant_results with the gene list ID
@@ -314,7 +314,7 @@ if (!is.character(significant_results[[i]][["CC"]]) && nrow(significant_results[
 
 # If there are any enriched categories, store the gene list in valid_gene_lists
 if (length(enriched_categories) > 0) {
-    valid_gene_lists[[paste("list", i)]] <- gene_lists$unique_genes[[i]]
+    valid_gene_lists[[paste0("list", i)]] <- gene_lists$unique_genes[[i]]
 
     # Create a message for enrichment and write it to the log file
     msg <- paste("Gene set", i, "has enriched categories:", paste(enriched_categories, collapse = ", "))
@@ -326,6 +326,14 @@ if (length(enriched_categories) > 0) {
 }
 }
 
-# Saving files
+# Tibble for valid gene lists
+valid_gene_lists_df <- tibble(
+gene_list = names(valid_gene_lists),
+genes = sapply(valid_gene_lists, function(x) paste(x, collapse = ","))
+)
+
+
+#### Save the resulting key files ####
+write.table(valid_gene_lists_df, file = "list_gene_association.tsv", sep = "\t", row.names = FALSE, quote = FALSE)
 saveRDS(valid_gene_lists, "valid_gene_lists.rds")
 saveRDS(transcript_data, "transcript_data.rds")

--- a/bin/subset_gff.R
+++ b/bin/subset_gff.R
@@ -336,4 +336,4 @@ genes = sapply(valid_gene_lists, function(x) paste(x, collapse = ","))
 #### Save the resulting key files ####
 write.table(valid_gene_lists_df, file = "list_gene_association.tsv", sep = "\t", row.names = FALSE, quote = FALSE)
 saveRDS(valid_gene_lists, "valid_gene_lists.rds")
-saveRDS(transcript_data, "transcript_data.rds")
+saveRDS(transcript_data, "filtered_gff3.rds")

--- a/modules/local/countmatrices/main.nf
+++ b/modules/local/countmatrices/main.nf
@@ -29,7 +29,7 @@ process COUNTMATRICES {
         '${meta.coverage}' \\
         '${meta.reps}' \\
         '${meta.groups}' \\
-        '${txfasta}' \\
+        '${filtered_txfasta}' \\
         '${filtered_gff3}' \\
         '${geneList}'
 

--- a/modules/local/countmatrices/main.nf
+++ b/modules/local/countmatrices/main.nf
@@ -8,7 +8,7 @@ process COUNTMATRICES {
         'community.wave.seqera.io/library/bioconductor-biostrings_r-tidyverse:4645f56e7256e01f' }"
 
     input:
-    tuple val(meta),  path(txfasta)
+    tuple val(meta),  path(filtered_txfasta)
     tuple val(meta2), path(filtered_gff3)
     tuple val(meta3), path(geneList)
 

--- a/modules/local/countmatrices/main.nf
+++ b/modules/local/countmatrices/main.nf
@@ -8,10 +8,9 @@ process COUNTMATRICES {
         'community.wave.seqera.io/library/bioconductor-biostrings_r-tidyverse:4645f56e7256e01f' }"
 
     input:
-    val(meta)
-    path(txfasta)
-    path(gff3)
-    path(geneList)
+    tuple val(meta),  path(txfasta)
+    tuple val(meta2), path(filtered_gff3)
+    tuple val(meta3), path(geneList)
 
     output:
     tuple val(meta), path ("countMatrix_*.rds")    , emit: simcountMatrix
@@ -31,7 +30,7 @@ process COUNTMATRICES {
         '${meta.reps}' \\
         '${meta.groups}' \\
         '${txfasta}' \\
-        '${gff3}' \\
+        '${filtered_gff3}' \\
         '${geneList}'
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/countmatrices/meta.yml
+++ b/modules/local/countmatrices/meta.yml
@@ -23,20 +23,32 @@ tools:
       licence: ["Artistic-2.0"]
       identifier: "bioconductor-biostrings"
 input:
-  - meta:
-      type: map
-      description: Metadata map
-  - txfasta:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+    - txfasta:
+        type: file
+        description: Transcriptome FASTA file containing transcripts from the specified chromosome
+        pattern: "*.{fa,fasta}"
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+    - filtered_gff3:
+        type: file
+        description: RDS file containing transcript data from the specified chromosome
+        pattern: "*.rds"
+  - - meta3:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+    - geneList:
       type: file
-      description: Transcriptome FASTA file
-      pattern: "*.{fa,fasta}"
-  - gff3:
-      type: file
-      description: GFF3 annotation file
-      pattern: "*.gff3"
-  - geneList:
-      type: file
-      description: Gene list file that should give an enrichment
+      description: RDS file containing valid gene lists
       pattern: "*.rds"
 output:
   - simcountMatrix:
@@ -44,17 +56,17 @@ output:
           type: map
           description: |
             Groovy Map containing sample information
-            e.g. `[ id: 'simulation_id', chromosome: 'chr_number', genes: 'A, B, C', reps: 3, groups: 2 ]`
-      - "countmatrix_*.rds":
+            e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+      - "countMatrix_*.rds":
           type: file
           description: RDS file containing the count matrices
-          pattern: "countmatrix_*.rds"
+          pattern: "countMatrix_*.rds"
   - simAnnords:
       - meta:
           type: map
           description: |
             Groovy Map containing sample information
-            e.g. `[ id: 'simulation_id', chromosome: 'chr_number', genes: 'A, B, C', reps: 3, groups: 2 ]`
+            e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
       - "expected_*.rds":
           type: file
           description: Gene info and expected log2 fold change in RDS format

--- a/modules/local/countmatrices/meta.yml
+++ b/modules/local/countmatrices/meta.yml
@@ -28,10 +28,10 @@ input:
         description: |
           Groovy Map containing sample information
           e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
-    - txfasta:
+    - filtered_txfasta:
         type: file
         description: Transcriptome FASTA file containing transcripts from the specified chromosome
-        pattern: "*.{fa,fasta}"
+        pattern: "gencode_transcripts_noversion.fasta"
   - - meta2:
         type: map
         description: |
@@ -40,7 +40,7 @@ input:
     - filtered_gff3:
         type: file
         description: RDS file containing transcript data from the specified chromosome
-        pattern: "*.rds"
+        pattern: "filtered_gff3.rds"
   - - meta3:
         type: map
         description: |
@@ -49,7 +49,7 @@ input:
     - geneList:
       type: file
       description: RDS file containing valid gene lists
-      pattern: "*.rds"
+      pattern: "valid_gene_lists.rds"
 output:
   - simcountMatrix:
       - meta:

--- a/modules/local/countmatrices/tests/main.nf.test
+++ b/modules/local/countmatrices/tests/main.nf.test
@@ -13,10 +13,18 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = [ id:'test', chromosome: 'chr22', coverage: '30', reps:'5', groups:'2' ]
-                input[1] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/countmatrices/gencode_transcripts_noversion_chr22.fasta', checkIfExists: true)
-                input[2] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/countmatrices/gff3_chr22.rds', checkIfExists: true)
-                input[3] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/countmatrices/valid_gene_lists.rds', checkIfExists: true)
+                input[0] = [
+                [ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ], // meta map
+                file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/countmatrices/gencode_transcripts_noversion_chr22.fasta', checkIfExists: true)
+                ]
+                input[1] = [
+                [ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ], // meta map
+                file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/countmatrices/transcriptData_chr22.rds', checkIfExists: true)
+                ]
+                input[2] = [
+                [ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ], // meta map
+                file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/countmatrices/small_gene_lists.rds', checkIfExists: true)
+                ]
                 """
             }
         }
@@ -41,19 +49,29 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = [ id:'test', chromosome: 'chr22', coverage: '30', reps:'5', groups:'2' ]
-                input[1] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/countmatrices/gencode_transcripts_noversion_chr22.fasta', checkIfExists: true)
-                input[2] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/countmatrices/gff3_chr22.rds', checkIfExists: true)
-                input[3] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/countmatrices/valid_gene_lists.rds', checkIfExists: true)
+                input[0] = [
+                [ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ], // meta map
+                file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/countmatrices/gencode_transcripts_noversion_chr22.fasta', checkIfExists: true)
+                ]
+                input[1] = [
+                [ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ], // meta map
+                file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/countmatrices/transcriptData_chr22.rds', checkIfExists: true)
+                ]
+                input[2] = [
+                [ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ], // meta map
+                file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/countmatrices/small_gene_lists.rds', checkIfExists: true)
+                ]
                 """
             }
         }
 
         then {
-             assertAll(
+            assertAll(
                 { assert process.success },
-                { assert process.out.simcountMatrix && process.out.simcountMatrix.size() > 0 },
-                { assert process.out.simAnnords && process.out.simAnnords.size() > 0 },
+                { assert process.out.simcountMatrix },
+                { assert process.out.simAnnords },
+                { assert process.out.simcountMatrix.get(0) && process.out.simcountMatrix.get(0).size() > 0 },
+                { assert process.out.simAnnords.get(0) && process.out.simAnnords.get(0).size() > 0 },
                 { assert process.out.versions && process.out.versions.size() > 0 }
             )
         }

--- a/modules/local/polyester/simulate/main.nf
+++ b/modules/local/polyester/simulate/main.nf
@@ -8,9 +8,9 @@ process POLYESTER_SIMULATE {
         'community.wave.seqera.io/library/bioconductor-biostrings_bioconductor-polyester:e85f578a0b8f70ca' }"
 
     input:
-    tuple val(meta), path(countmatrix)
+    tuple val(meta),  path(countmatrix)
     tuple val(meta2), path(foldchange)
-    path(txfasta)
+    tuple val(meta3), path(filtered_txfasta)
 
     output:
     tuple val(meta), path('simulated_reads/*.fasta.gz'), emit: reads
@@ -29,8 +29,8 @@ process POLYESTER_SIMULATE {
     def readData = countmatrix ? "countmat = readRDS('${countmatrix}')" : "fold_changes = readRDS('${foldchange}')"
     def readsPerTxFactor = meta.coverage ?: 30
     def simulation_function = countmatrix ?
-        "simulate_experiment_countmat('${txfasta}', readmat=countmat, outdir='simulated_reads')" :
-        "simulate_experiment('${txfasta}', reads_per_transcript=readspertx, ${numRepsString}, fold_changes=fold_changes, outdir='simulated_reads')"
+        "simulate_experiment_countmat('${filtered_txfasta}', readmat=countmat, outdir='simulated_reads')" :
+        "simulate_experiment('${filtered_txfasta}', reads_per_transcript=readspertx, ${numRepsString}, fold_changes=fold_changes, outdir='simulated_reads')"
 
     """
     cat <<EOF >simulate_reads.R
@@ -40,7 +40,7 @@ process POLYESTER_SIMULATE {
     library(Biostrings)
 
     # Load the fasta
-    fasta <- readDNAStringSet("${txfasta}")
+    fasta <- readDNAStringSet("${filtered_txfasta}")
     readspertx = round(${readsPerTxFactor} * width(fasta) / 100)
 
     # Load the count matrix or fold changes

--- a/modules/local/polyester/simulate/meta.yml
+++ b/modules/local/polyester/simulate/meta.yml
@@ -22,7 +22,7 @@ input:
         type: map
         description: |
           Groovy Map containing sample information
-          e.g. `[ id:'simulation_id', reps:3, groups:2 ]`
+          e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
     - countmatrix:
         type: file
         description: RDS file containing transcripts counts to be simulated
@@ -35,7 +35,7 @@ input:
         type: map
         description: |
           Groovy Map containing sample information
-          e.g. `[ id:'simulation_id', reps:3, groups:2 ]`
+          e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
     - foldchange:
         type: file
         description: RDS file containing fold changes to be simulated for different transcripts
@@ -44,11 +44,15 @@ input:
           - edam: "http://edamontology.org/format_25722"
           - edam: "http://edamontology.org/format_2573"
           - edam: "http://edamontology.org/format_3462"
-  - - txfasta:
+  - - meta3:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+    - filtered_txfasta:
         type: file
-        description: FASTA file containing sequences of the transcripts to be simulated
+        description: Subset FASTA file containing transcripts from the specified chromosome
         pattern: "*.fasta"
-
 output:
   - reads:
       #Only when we have meta
@@ -65,13 +69,11 @@ output:
             - edam: "http://edamontology.org/format_25722"
             - edam: "http://edamontology.org/format_2573"
             - edam: "http://edamontology.org/format_3462"
-
   - versions:
       - "versions.yml":
           type: file
           description: File containing software versions
           pattern: "versions.yml"
-
 authors:
   - "@lescai"
 maintainers:

--- a/modules/local/polyester/simulate/tests/main.nf.test
+++ b/modules/local/polyester/simulate/tests/main.nf.test
@@ -14,14 +14,17 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test', reps:3, groups:2, coverage:50 ], // meta map
+                    [ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ], // meta map
                     file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/polyester/countmatrix_testdata.rds', checkIfExists: true)
                 ]
                 input[1] = [
                     [ id:'null' ], // meta map
                     []
                 ]
-                input[2] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/gencode_transcripts_noversion_chr22_sampled.fasta', checkIfExists: true)
+                input[2] = [
+                    [ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ], // meta map
+                    file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/gencode_transcripts_noversion_chr22_sampled.fasta', checkIfExists: true)
+                ]
                 """
             }
         }
@@ -44,10 +47,13 @@ nextflow_process {
                     []
                 ]
                 input[1] = [
-                    [ id:'test', reps:3, groups:2, coverage:50 ], // meta map
+                    [ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ], // meta map
                     file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/polyester/fcmatrix_testdata.rds', checkIfExists: true)
                 ]
-                input[2] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/gencode_transcripts_noversion_chr22_sampled.fasta', checkIfExists: true)
+                input[2] = [
+                    [ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ], // meta map
+                    file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/gencode_transcripts_noversion_chr22_sampled.fasta', checkIfExists: true)
+                ]
                 """
             }
         }
@@ -68,14 +74,17 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test', reps:3, groups:2, coverage:50 ], // meta map
+                    [ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ], // meta map
                     file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/polyester/countmatrix_testdata.rds', checkIfExists: true)
                 ]
                 input[1] = [
                     [ id:'null' ], // meta map
                     []
                 ]
-                input[2] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/gencode_transcripts_noversion_chr22_sampled.fasta', checkIfExists: true)
+                input[2] = [
+                    [ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ], // meta map
+                    file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/gencode_transcripts_noversion_chr22_sampled.fasta', checkIfExists: true)
+                ]
                 """
             }
         }

--- a/modules/local/subsetfastatx/main.nf
+++ b/modules/local/subsetfastatx/main.nf
@@ -13,9 +13,9 @@ process SUBSETFASTATX {
     path(gff3)
 
     output:
-    path "*.fasta"                        , emit: fasta
-    path "subsetfastatx_parsing_log.txt"  , emit: log
-    path "versions.yml"                   , emit: versions
+    tuple val(meta), path ("*.fasta")                        , emit: fasta
+    tuple val(meta), path ("subsetfastatx_parsing_log.txt")  , emit: log
+    path "versions.yml"                                      , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -38,6 +38,7 @@ process SUBSETFASTATX {
     stub:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+
     """
     touch gencode_transcripts_noversion_${meta.chromosome}.fasta
     touch subsetfastatx_parsing_log.txt

--- a/modules/local/subsetfastatx/main.nf
+++ b/modules/local/subsetfastatx/main.nf
@@ -13,9 +13,9 @@ process SUBSETFASTATX {
     path(gff3)
 
     output:
-    tuple val(meta), path ("*.fasta")                        , emit: fasta
-    tuple val(meta), path ("subsetfastatx_parsing_log.txt")  , emit: log
-    path "versions.yml"                                      , emit: versions
+    tuple val(meta), path ("gencode_transcripts_noversion.fasta")    , emit: fasta
+    tuple val(meta), path ("subsetfastatx_parsing_log.txt")          , emit: log
+    path "versions.yml"                                              , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -40,7 +40,7 @@ process SUBSETFASTATX {
     def prefix = task.ext.prefix ?: "${meta.id}"
 
     """
-    touch gencode_transcripts_noversion_${meta.chromosome}.fasta
+    touch gencode_transcripts_noversion.fasta
     touch subsetfastatx_parsing_log.txt
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/subsetfastatx/main.nf
+++ b/modules/local/subsetfastatx/main.nf
@@ -13,7 +13,7 @@ process SUBSETFASTATX {
     path(gff3)
 
     output:
-    tuple val(meta), path ("gencode_transcripts_noversion.fasta")    , emit: fasta
+    tuple val(meta), path ("gencode_transcripts_noversion.fasta")    , emit: filtered_fasta
     tuple val(meta), path ("subsetfastatx_parsing_log.txt")          , emit: log
     path "versions.yml"                                              , emit: versions
 

--- a/modules/local/subsetfastatx/meta.yml
+++ b/modules/local/subsetfastatx/meta.yml
@@ -22,7 +22,9 @@ tools:
 input:
   - meta:
       type: map
-      description: Metadata map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
   - txfasta:
       type: file
       description: Transcriptome FASTA file
@@ -32,11 +34,12 @@ input:
       description: GFF3 annotation file
       pattern: "*.{gff3}"
 output:
-  - fasta:
+  - filtered_fasta:
       - meta:
           type: file
-          description: Subset FASTA file containing transcripts from the specified chromosome
-          pattern: "gencode_transcripts_noversion.fasta"
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
       - "gencode_transcripts_noversion.fasta":
           type: file
           description: Subset FASTA file containing transcripts from the specified chromosome
@@ -44,8 +47,9 @@ output:
   - log:
       - meta:
           type: file
-          description: Log file containing parsing and analysis information
-          pattern: "subsetfastatx_parsing_log.txt"
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
       - "subsetfastatx_parsing_log.txt":
           type: file
           description: Log file containing parsing and analysis information

--- a/modules/local/subsetfastatx/meta.yml
+++ b/modules/local/subsetfastatx/meta.yml
@@ -36,11 +36,11 @@ output:
       - meta:
           type: file
           description: Subset FASTA file containing transcripts from the specified chromosome
-          pattern: "gencode_transcripts_noversion_dummy.fasta"
-      - "gencode_transcripts_noversion_dummy.fasta":
+          pattern: "gencode_transcripts_noversion.fasta"
+      - "gencode_transcripts_noversion.fasta":
           type: file
           description: Subset FASTA file containing transcripts from the specified chromosome
-          pattern: "gencode_transcripts_noversion_dummy.fasta"
+          pattern: "gencode_transcripts_noversion.fasta"
   - log:
       - meta:
           type: file

--- a/modules/local/subsetfastatx/meta.yml
+++ b/modules/local/subsetfastatx/meta.yml
@@ -33,13 +33,23 @@ input:
       pattern: "*.{gff3}"
 output:
   - fasta:
-      type: file
-      description: Subset FASTA file containing transcripts from the specified chromosome
-      pattern: "gencode_transcripts_noversion_dummy.fasta"
+      - meta:
+          type: file
+          description: Subset FASTA file containing transcripts from the specified chromosome
+          pattern: "gencode_transcripts_noversion_dummy.fasta"
+      - "gencode_transcripts_noversion_dummy.fasta":
+          type: file
+          description: Subset FASTA file containing transcripts from the specified chromosome
+          pattern: "gencode_transcripts_noversion_dummy.fasta"
   - log:
-      type: file
-      description: Log file containing parsing information
-      pattern: "parsing_log.txt"
+      - meta:
+          type: file
+          description: Log file containing parsing and analysis information
+          pattern: "subsetfastatx_parsing_log.txt"
+      - "subsetfastatx_parsing_log.txt":
+          type: file
+          description: Log file containing parsing and analysis information
+          pattern: "subsetfastatx_parsing_log.txt"
   - versions:
       type: file
       description: File containing software versions

--- a/modules/local/subsetfastatx/tests/main.nf.test
+++ b/modules/local/subsetfastatx/tests/main.nf.test
@@ -13,7 +13,7 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = [ id:'test', chromosome:'chr22' ]
+                input[0] = [ id:'test', chromosome: 'chr22', coverage: '30', reps:'3', groups:'2', simthreshold: '0.3' ]
                 input[1] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/subsetfastatx/gencode_transcripts_noversion_chr21_chr22.fasta', checkIfExists: true)
                 input[2] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/subsetfastatx/gencode_chr21_chr22_v47.gff3', checkIfExists: true)
                 """
@@ -23,7 +23,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert process.out.fasta.get(0).endsWith('.fasta') },
+                { assert process.out.fasta.get(0).get(1).endsWith('.fasta') },
                 { assert process.out.versions }
             )
         }
@@ -37,7 +37,7 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = [ id:'test', chromosome:'chr22']
+                input[0] = [ id:'test', chromosome: 'chr22', coverage: '30', reps:'3', groups:'2', simthreshold: '0.3']
                 input[1] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/subsetfastatx/gencode_transcripts_noversion_chr21_chr22.fasta', checkIfExists: true)
                 input[2] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/subsetfastatx/gencode_chr21_chr22_v47.gff3', checkIfExists: true)
                 """
@@ -47,7 +47,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert process.out.fasta.get(0).endsWith('.fasta') },
+                { assert process.out.fasta.get(0).get(1).endsWith('.fasta') },
                 { assert process.out.versions }
             )
         }

--- a/modules/local/subsetfastatx/tests/main.nf.test
+++ b/modules/local/subsetfastatx/tests/main.nf.test
@@ -13,7 +13,7 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = [ id:'test', chromosome: 'chr22', coverage: '30', reps:'3', groups:'2', simthreshold: '0.3' ]
+                input[0] = [ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]
                 input[1] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/subsetfastatx/gencode_transcripts_noversion_chr21_chr22.fasta', checkIfExists: true)
                 input[2] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/subsetfastatx/gencode_chr21_chr22_v47.gff3', checkIfExists: true)
                 """
@@ -23,7 +23,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert process.out.fasta.get(0).get(1).endsWith('.fasta') },
+                { assert process.out.filtered_fasta.get(0).get(1).endsWith('.fasta') },
                 { assert process.out.versions }
             )
         }
@@ -37,7 +37,7 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = [ id:'test', chromosome: 'chr22', coverage: '30', reps:'3', groups:'2', simthreshold: '0.3']
+                input[0] = [ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]
                 input[1] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/subsetfastatx/gencode_transcripts_noversion_chr21_chr22.fasta', checkIfExists: true)
                 input[2] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/subsetfastatx/gencode_chr21_chr22_v47.gff3', checkIfExists: true)
                 """
@@ -47,7 +47,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert process.out.fasta.get(0).get(1).endsWith('.fasta') },
+                { assert process.out.filtered_fasta.get(0).get(1).endsWith('.fasta') },
                 { assert process.out.versions }
             )
         }

--- a/modules/local/subsetgff/main.nf
+++ b/modules/local/subsetgff/main.nf
@@ -14,7 +14,7 @@ process SUBSETGFF {
     output:
     tuple val(meta), path("valid_gene_lists.rds")        , emit: geneLists
     tuple val(meta), path("list_gene_association.tsv")   , emit: genes_list_association
-    tuple val(meta), path("transcript_data.rds")         , emit: transcriptData
+    tuple val(meta), path("filtered_gff3.rds")           , emit: filtered_gff3
     tuple val(meta), path("subsetgff_parsing_log.txt")   , emit: log
     path "versions.yml"                                  , emit: versions
 
@@ -50,7 +50,7 @@ process SUBSETGFF {
     """
     touch valid_gene_lists.rds
     touch list_gene_association.tsv
-    touch transcript_data.rds
+    touch filtered_gff3.rds
     touch subsetgff_parsing_log.txt
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/subsetgff/main.nf
+++ b/modules/local/subsetgff/main.nf
@@ -12,10 +12,11 @@ process SUBSETGFF {
     path(gff3)
 
     output:
-    path "valid_gene_lists.rds"       , emit: geneLists
-    path "transcript_data.rds"        , emit: transcriptData
-    path "subsetgff_parsing_log.txt"  , emit: log
-    path "versions.yml"               , emit: versions
+    tuple val(meta), path("valid_gene_lists.rds")        , emit: geneLists
+    tuple val(meta), path("list_gene_association.tsv")   , emit: genes_list_association
+    tuple val(meta), path("transcript_data.rds")         , emit: transcriptData
+    tuple val(meta), path("subsetgff_parsing_log.txt")   , emit: log
+    path "versions.yml"                                  , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -48,6 +49,7 @@ process SUBSETGFF {
 
     """
     touch valid_gene_lists.rds
+    touch list_gene_association.tsv
     touch transcript_data.rds
     touch subsetgff_parsing_log.txt
 

--- a/modules/local/subsetgff/meta.yml
+++ b/modules/local/subsetgff/meta.yml
@@ -91,10 +91,8 @@ input:
   - meta:
       type: map
       description: |
-        Metadata map containing sample information
-        Required keys:
-          - id: Sample identifier
-          - chromosome: Chromosome of interest
+        Groovy Map containing sample information
+        e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
   - gff3:
       type: file
       description: GFF3 annotation file
@@ -103,35 +101,39 @@ output:
   - geneLists:
       - meta:
           type: file
-          description: RDS file containing valid gene lists
-          pattern: "valid_gene_lists.rds"
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
       - "valid_gene_lists.rds":
           type: file
           description: RDS file containing valid gene lists
           pattern: "valid_gene_lists.rds"
   - genes_list_association:
       - meta:
-          type: file
-          description: TSV file containing the association between genes and the corrisponding list
-          pattern: "list_gene_association.tsv"
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
       - "list_gene_association.tsv":
           type: file
           description: TSV file containing the association between genes and the corrisponding list
           pattern: "list_gene_association.tsv"
-  - transcriptData:
+  - filtered_gff3:
       - meta:
           type: file
-          description: RDS file containing transcript data
-          pattern: "list_gene_association.tsv"
-      - "transcript_data.rds":
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+      - "filtered_gff3.rds":
           type: file
-          description: RDS file containing transcript data
-          pattern: "transcript_data.rds"
+          description: RDS file containing transcript data from the specified chromosome
+          pattern: "filtered_gff3.rds"
   - log:
       - meta:
           type: file
-          description: Log file containing parsing and analysis information
-          pattern: "subsetgff_parsing_log.txt"
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
       - "subsetgff_parsing_log.txt":
           type: file
           description: Log file containing parsing and analysis information
@@ -140,7 +142,6 @@ output:
       type: file
       description: File containing software versions
       pattern: "versions.yml"
-
 authors:
   - "@carpanz"
   - "@LorenzoS96"

--- a/modules/local/subsetgff/meta.yml
+++ b/modules/local/subsetgff/meta.yml
@@ -101,21 +101,46 @@ input:
       pattern: "*.{gff,gff3}"
 output:
   - geneLists:
-      type: file
-      description: RDS file containing valid gene lists
-      pattern: "valid_gene_lists.rds"
+      - meta:
+          type: file
+          description: RDS file containing valid gene lists
+          pattern: "valid_gene_lists.rds"
+      - "valid_gene_lists.rds":
+          type: file
+          description: RDS file containing valid gene lists
+          pattern: "valid_gene_lists.rds"
+  - genes_list_association:
+      - meta:
+          type: file
+          description: TSV file containing the association between genes and the corrisponding list
+          pattern: "list_gene_association.tsv"
+      - "list_gene_association.tsv":
+          type: file
+          description: TSV file containing the association between genes and the corrisponding list
+          pattern: "list_gene_association.tsv"
   - transcriptData:
-      type: file
-      description: RDS file containing transcript data
-      pattern: "transcript_data.rds"
+      - meta:
+          type: file
+          description: RDS file containing transcript data
+          pattern: "list_gene_association.tsv"
+      - "transcript_data.rds":
+          type: file
+          description: RDS file containing transcript data
+          pattern: "transcript_data.rds"
   - log:
-      type: file
-      description: Log file containing parsing and analysis information
-      pattern: "parsing_log.txt"
+      - meta:
+          type: file
+          description: Log file containing parsing and analysis information
+          pattern: "subsetgff_parsing_log.txt"
+      - "subsetgff_parsing_log.txt":
+          type: file
+          description: Log file containing parsing and analysis information
+          pattern: "subsetgff_parsing_log.txt"
   - versions:
       type: file
       description: File containing software versions
       pattern: "versions.yml"
+
 authors:
   - "@carpanz"
   - "@LorenzoS96"

--- a/modules/local/subsetgff/tests/main.nf.test
+++ b/modules/local/subsetgff/tests/main.nf.test
@@ -16,7 +16,7 @@ nextflow_process {
             process {
                 """
 
-                input[0] = [ id:'test', chromosome: 'chr22', coverage: '30', reps:'3', groups:'2', simthreshold: '0.3' ]
+                input[0] = [ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]
                 input[1] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/subsetfastatx/gencode_chr21_chr22_v47.gff3', checkIfExists: true)
 
                 """
@@ -28,7 +28,7 @@ nextflow_process {
                 { assert process.success },
                 { assert process.out.geneLists.get(0).get(1).endsWith('.rds') },
                 { assert process.out.genes_list_association.get(0).get(1).endsWith('.tsv') },
-                { assert process.out.transcriptData.get(0).get(1).endsWith('.rds') },
+                { assert process.out.filtered_gff3.get(0).get(1).endsWith('.rds') },
                 { assert process.out.versions }
             )
         }
@@ -43,7 +43,7 @@ nextflow_process {
             process {
                 """
 
-                input[0] = [ id:'test', chromosome: 'chr22', coverage: '30', reps:'3', groups:'2', simthreshold: '0.3' ]
+                input[0] = [ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]
                 input[1] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/subsetfastatx/gencode_chr21_chr22_v47.gff3', checkIfExists: true)
 
                 """
@@ -55,7 +55,7 @@ nextflow_process {
                 { assert process.success },
                 { assert process.out.geneLists.get(0).get(1).endsWith('.rds') },
                 { assert process.out.genes_list_association.get(0).get(1).endsWith('.tsv') },
-                { assert process.out.transcriptData.get(0).get(1).endsWith('.rds') },
+                { assert process.out.filtered_gff3.get(0).get(1).endsWith('.rds') },
                 { assert process.out.versions }
             )
         }

--- a/modules/local/subsetgff/tests/main.nf.test
+++ b/modules/local/subsetgff/tests/main.nf.test
@@ -16,7 +16,7 @@ nextflow_process {
             process {
                 """
 
-                input[0] = [ id:'test', chromosome:'chr22', simthreshold: '0.3' ]
+                input[0] = [ id:'test', chromosome: 'chr22', coverage: '30', reps:'3', groups:'2', simthreshold: '0.3' ]
                 input[1] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/subsetfastatx/gencode_chr21_chr22_v47.gff3', checkIfExists: true)
 
                 """
@@ -43,7 +43,7 @@ nextflow_process {
             process {
                 """
 
-                input[0] = [ id:'test', chromosome:'chr22', simthreshold: '0.3' ]
+                input[0] = [ id:'test', chromosome: 'chr22', coverage: '30', reps:'3', groups:'2', simthreshold: '0.3' ]
                 input[1] = file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/subsetfastatx/gencode_chr21_chr22_v47.gff3', checkIfExists: true)
 
                 """

--- a/modules/local/subsetgff/tests/main.nf.test
+++ b/modules/local/subsetgff/tests/main.nf.test
@@ -26,8 +26,9 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert process.out.geneLists.get(0).endsWith('.rds') },
-                { assert process.out.transcriptData.get(0).endsWith('.rds') },
+                { assert process.out.geneLists.get(0).get(1).endsWith('.rds') },
+                { assert process.out.genes_list_association.get(0).get(1).endsWith('.tsv') },
+                { assert process.out.transcriptData.get(0).get(1).endsWith('.rds') },
                 { assert process.out.versions }
             )
         }
@@ -52,8 +53,9 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert process.out.geneLists.get(0).endsWith('.rds') },
-                { assert process.out.transcriptData.get(0).endsWith('.rds') },
+                { assert process.out.geneLists.get(0).get(1).endsWith('.rds') },
+                { assert process.out.genes_list_association.get(0).get(1).endsWith('.tsv') },
+                { assert process.out.transcriptData.get(0).get(1).endsWith('.rds') },
                 { assert process.out.versions }
             )
         }


### PR DESCRIPTION
PR to :
- add the meta in the output subsetfastatx module
- add the meta in the output subsetgff module and add an additional output useful in the prepare_simulate_rnaseq_reads subworkflow to associate each gene list with its genes 
- add the meta in the input countmatrices module
- add the meta in the input polyester module

Of course I also changed the corresponding meta.yml and main.nf.test when necessary. I also preferred to modify the name of some inputs and outputs in the different modules to be more explicit about those files.

nf-test working with:

- [x] nf-test test --profile conda
- [x] nf-test modules test --profile singularity
- [x]  nf-test modules test --profile docker
