### PR TITLE
Update prepare_rna_genome subworkflow

### DIFF
--- a/modules/local/subsetfastatx/environment.yml
+++ b/modules/local/subsetfastatx/environment.yml
@@ -7,4 +7,3 @@ dependencies:
   - bioconda::bioconductor-biostrings=2.68.1
   - bioconda::bioconductor-rtracklayer=1.60.0
   - conda-forge::r-tidyverse=2.0.0
-  - conda-forge::r-base=4.3

--- a/modules/local/subsetfastatx/main.nf
+++ b/modules/local/subsetfastatx/main.nf
@@ -13,7 +13,7 @@ process SUBSETFASTATX {
     path(gff3)
 
     output:
-    tuple val(meta), path ("gencode_transcripts_noversion.fasta")    , emit: filtered_fasta
+    tuple val(meta), path ("gencode_transcripts_noversion.fasta")    , emit: filtered_txfasta
     tuple val(meta), path ("subsetfastatx_parsing_log.txt")          , emit: log
     path "versions.yml"                                              , emit: versions
 

--- a/modules/local/subsetfastatx/meta.yml
+++ b/modules/local/subsetfastatx/meta.yml
@@ -1,5 +1,5 @@
 name: SUBSETFASTATX
-description: Subsets a FASTA file based on a specified chromosome and GFF3 annotations
+description: subsets a FASTA file based on a specified chromosome and GFF3 annotations
 keywords:
   - fasta
   - subset
@@ -34,7 +34,7 @@ input:
       description: GFF3 annotation file
       pattern: "*.{gff3}"
 output:
-  - filtered_fasta:
+  - filtered_txfasta:
       - meta:
           type: file
           description: |

--- a/modules/local/subsetfastatx/tests/main.nf.test
+++ b/modules/local/subsetfastatx/tests/main.nf.test
@@ -23,7 +23,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert process.out.filtered_fasta.get(0).get(1).endsWith('.fasta') },
+                { assert process.out.filtered_txfasta.get(0).get(1).endsWith('.fasta') },
                 { assert process.out.versions }
             )
         }
@@ -47,7 +47,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert process.out.filtered_fasta.get(0).get(1).endsWith('.fasta') },
+                { assert process.out.filtered_txfasta.get(0).get(1).endsWith('.fasta') },
                 { assert process.out.versions }
             )
         }

--- a/subworkflows/local/prepare_rna_genome/meta.yml
+++ b/subworkflows/local/prepare_rna_genome/meta.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
 name: "prepare_rna_genome"
-description: Prepares RNA genome data by subsetting FASTA and GFF files, and creating a Salmon index
+description: prepares RNA genome data by subsetting FASTA and GFF files, and creating a Salmon index
 keywords:
   - rna
   - genome
@@ -43,37 +43,86 @@ output:
         Channel containing Salmon index directory
         Structure: [ path(salmon_index) ]
       pattern: "salmon_index"
-  - txfasta:
-      type: file
+  - filtered_txfasta:
       description: |
-        Channel containing subset transcript FASTA file
-        Structure: [ path(txfasta) ]
-      pattern: "*.{fa,fasta}"
+        Channel containing the filtered txfasta file with the transcripts from the specified chromosome
+        Structure: [ val(meta), path(txfasta) ]
+      structure:
+        - meta:
+            type: map
+            description: |
+              Groovy Map containing sample information
+              e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+        - filtered_txfasta:
+            type: file
+            description: Subset FASTA file containing transcripts from the specified chromosome
+            pattern: "gencode_transcripts_noversion.fasta"
   - gene_lists:
-      type: file
       description: |
         Channel containing gene lists from subset GFF
-        Structure: [ path(gene_lists) ]
-      pattern: "*.{rds}"
-  - transcript_data:
-      type: file
+        Structure: [ val(meta), path(gene_lists)  ]
+      structure:
+        - meta:
+            type: map
+            description: |
+              Groovy Map containing sample information
+              e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+        - gene_lists:
+            type: file
+            description: RDS file containing valid gene lists
+            pattern: "valid_gene_lists.rds"
+  - genes_list_associations:
       description: |
-        Channel containing transcript data from subset GFF
-        Structure: [ path(transcript_data) ]
-      pattern: "*.{rds}"
+        Channel containing the association between a list and its gene
+        Structure: [ val(meta), path(genes_list_associations)  ]
+      structure:
+        - meta:
+            type: map
+            description: |
+              Groovy Map containing sample information
+              e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+        - genes_list_associations:
+            type: file
+            description: TSV file containing the association between genes and the corrisponding list
+            pattern: "list_gene_association.tsv"
+  - filtered_gff3:
+      description: |
+        Channel containing the filtered gff3 file with the transcripts from the specified chromosome
+        Structure: [ val(meta), path(filtered_gff3)  ]
+      structure:
+        - meta:
+            type: map
+            description: |
+              Groovy Map containing sample information
+              e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+        - filtered_gff3:
+            type: file
+            description: RDS file containing transcript data from the specified chromosome
+            pattern: "filtered_gff3.rds"
   - log_files:
-      type: file
       description: |
-        Channel containing log files from the local modules subsetfastatx and subsetgff
-        Structure: [ path(log_files) ]
-      pattern: "*.txt"
+        Channel containing log files from the modules subsetfastatx and subsetgff
+        Structure: [ val(meta), path(log_files)  ]
+      structure:
+        - meta:
+            type: map
+            description: |
+              Groovy Map containing sample information
+              e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+        - log_files:
+            type: file
+            description: TXT file containing containing parsing and analysis information
+            pattern: "*.txt"
   - versions:
-      type: file
       description: |
-        File containing software versions
-        Structure: [ path(versions.yml) ]
-      pattern: "versions.yml"
+        Channel containing software versions file
+      structure:
+        - versions.yml:
+            type: file
+            description: File containing versions of the software used
 authors:
   - "@carpanz"
+  - "@LorenzoS96"
 maintainers:
   - "@carpanz"
+  - "@LorenzoS96"

--- a/subworkflows/local/prepare_rna_genome/meta.yml
+++ b/subworkflows/local/prepare_rna_genome/meta.yml
@@ -46,7 +46,7 @@ output:
   - filtered_txfasta:
       description: |
         Channel containing the filtered txfasta file with the transcripts from the specified chromosome
-        Structure: [ val(meta), path(txfasta) ]
+        Structure: [ val(meta), path(filtered_txfasta) ]
       structure:
         - meta:
             type: map

--- a/subworkflows/local/prepare_rna_genome/tests/main.nf.test
+++ b/subworkflows/local/prepare_rna_genome/tests/main.nf.test
@@ -4,7 +4,6 @@ nextflow_workflow {
     script "../main.nf"
     workflow "PREPARE_RNA_GENOME"
 
-    config "./test.config"
     options "-dump-channels"
 
     tag "subworkflows"
@@ -23,10 +22,10 @@ nextflow_workflow {
             workflow {
                 """
 
-                input[0] = Channel.of(file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/whole_chr22/Homo_sapiens.GRCh38.dna.chromosome.22.fa', checkIfExists: true))
+                input[0] = Channel.value(file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/whole_chr22/Homo_sapiens.GRCh38.dna.chromosome.22.fa', checkIfExists: true))
                 input[1] = Channel.value(file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/subsetfastatx/gencode_transcripts_noversion_chr21_chr22.fasta', checkIfExists: true))
                 input[2] = Channel.value(file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/subsetfastatx/gencode_chr21_chr22_v47.gff3', checkIfExists: true))
-                input[3] = Channel.of([ id:'test', chromosome:'chr22', simthreshold: '0.3' ])
+                input[3] = Channel.of([ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ])
 
                 """
             }
@@ -35,10 +34,17 @@ nextflow_workflow {
         then {
             assertAll(
                 { assert workflow.success },
-                { assert workflow.out.txfasta.get(0).endsWith('.fasta') },
-                { assert workflow.out.gene_lists.get(0).endsWith('.rds') },
-                { assert workflow.out.transcript_data.get(0).endsWith('.rds') },
-                { assert workflow.out.log_files.flatten().every { it.toString().endsWith('.txt') } }
+                {
+                    def indexDir = path(workflow.out.txfasta_index[0]).toFile()
+                    assert indexDir.exists()
+                    assert indexDir.isDirectory()
+                    assert indexDir.listFiles().size() > 0
+                },
+                { assert workflow.out.filtered_txfasta.get(0).get(1).endsWith('.fasta') },
+                { assert workflow.out.gene_lists.get(0).get(1).endsWith('.rds') },
+                { assert workflow.out.genes_list_associations.get(0).get(1).endsWith('.tsv') },
+                { assert workflow.out.filtered_gff3.get(0).get(1).endsWith('.rds') },
+                { assert workflow.out.log_files.collect { it[1] }.every { it.endsWith('.txt') } }
             )
         }
     }

--- a/subworkflows/local/prepare_rna_genome/tests/test.config
+++ b/subworkflows/local/prepare_rna_genome/tests/test.config
@@ -1,7 +1,0 @@
-process {
-    resourceLimits = [
-        memory: 6.GB,
-        cpus: 2,
-        time: 1.h
-    ]
-}


### PR DESCRIPTION
PR to modify and correct the subsetfastatx module and the prepare_rna_genome subworkflow:
- correction output name in the main, meta and tests of subsetfastatx module
- remove the meta for salmon index in the prepare_rna_genome subworkflow
- correct the emissions of the prepare_rna_genome subworkflow
- update the meta and the tests of the prepare_rna_genome subworkflow in accordance with the previous changes

After the changes, the module and the subworkflow have been tested.
nf-test working with:
- [x] nf-test test --profile conda
- [x] nf-test modules test --profile singularity
- [x]  nf-test modules test --profile docker
