### PR TITLE
rnaseq validation module

### DIFF
--- a/modules/local/rnaseqvalidation/environment.yml
+++ b/modules/local/rnaseqvalidation/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::bioconductor-dose=4.0.0

--- a/modules/local/rnaseqvalidation/main.nf
+++ b/modules/local/rnaseqvalidation/main.nf
@@ -1,0 +1,84 @@
+process RNASEQVALIDATION {
+    tag '$meta.id'
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'oras://community.wave.seqera.io/library/bioconductor-dose:4.0.0--5dccd2d8d274537d':
+        'community.wave.seqera.io/library/bioconductor-dose:4.0.0--57136ca31aaf6317' }"
+
+    input:
+    tuple val(meta),  path(enrichment_results)
+    tuple val(meta2), path(reads)
+    tuple val(meta3), path(de_genes)
+
+    output:
+    tuple val(meta), path("validated_reads/*.fasta.gz")    , optional: true, emit: valid_reads
+    tuple val(meta), path("validated_de_genes.txt")        , optional: true, emit: valid_de_genes
+    tuple val(meta), path("validation_result.txt")         , emit: validation_result
+    path "versions.yml"                                    , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    cat <<EOF > validate_enrichment.R
+    #!/usr/bin/env Rscript
+
+    library(DOSE)
+
+    enrichment_results <- readRDS("${enrichment_results}")
+    validate_enrichment <- function(enrichment_results) {
+        categories <- intersect(names(enrichment_results), c("BP", "MF", "CC"))
+
+        for (cat in categories) {
+            if (dim(enrichment_results[[cat]])[1] > 3) {
+                write("VALIDATION GOOD", file = "validation_result.txt")
+                return(invisible(NULL))
+            }
+        }
+
+        write("VALIDATION NOT GOOD", file = "validation_result.txt")
+        return(invisible(NULL))
+    }
+
+    validate_enrichment(enrichment_results)
+    EOF
+
+    Rscript validate_enrichment.R
+
+    if [ "\$(cat validation_result.txt)" == "VALIDATION GOOD" ]; then
+        mkdir -p validated_reads
+        for read_file in ${reads}; do
+            ln -s "\$(readlink -f "\$read_file")" validated_reads/
+        done
+        cp ${de_genes} validated_de_genes.txt
+    fi
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bioconductor-DOSE: \$(Rscript -e "cat(as.character(packageVersion('DOSE')))")
+    END_VERSIONS
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    mkdir -p validated_reads
+    touch validated_reads/${prefix}_1.fasta.gz
+    touch validated_reads/${prefix}_2.fasta.gz
+    touch validated_de_genes.txt
+    touch validation_result.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bioconductor-DOSE: \$(Rscript -e "cat(as.character(packageVersion('DOSE')))")
+    END_VERSIONS
+    """
+}

--- a/modules/local/rnaseqvalidation/main.nf
+++ b/modules/local/rnaseqvalidation/main.nf
@@ -1,5 +1,5 @@
 process RNASEQVALIDATION {
-    tag '$meta.id'
+    tag "$meta.id"
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
@@ -37,12 +37,12 @@ process RNASEQVALIDATION {
 
         for (cat in categories) {
             if (dim(enrichment_results[[cat]])[1] > 3) {
-                write("VALIDATION GOOD", file = "validation_result.txt")
+                write("GOOD SIMULATION", file = "validation_result.txt")
                 return(invisible(NULL))
             }
         }
 
-        write("VALIDATION NOT GOOD", file = "validation_result.txt")
+        write("SIMULATION NOT GOOD", file = "validation_result.txt")
         return(invisible(NULL))
     }
 
@@ -51,7 +51,7 @@ process RNASEQVALIDATION {
 
     Rscript validate_enrichment.R
 
-    if [ "\$(cat validation_result.txt)" == "VALIDATION GOOD" ]; then
+    if [ "\$(cat validation_result.txt)" == "GOOD SIMULATION" ]; then
         mkdir -p validated_reads
         for read_file in ${reads}; do
             ln -s "\$(readlink -f "\$read_file")" validated_reads/

--- a/modules/local/rnaseqvalidation/meta.yml
+++ b/modules/local/rnaseqvalidation/meta.yml
@@ -1,0 +1,85 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "rnaseqvalidation"
+description: validates RNA-seq enrichment results
+keywords:
+  - rnaseq
+  - validation
+  - enrichment
+tools:
+  - DOSE:
+      description: "R/Bioconductor package for Disease Ontology Semantic and Enrichment analysis"
+      homepage: "https://bioconductor.org/packages/release/bioc/html/DOSE.html"
+      documentation: "https://yulab-smu.top/biomedical-knowledge-mining-book/"
+      tool_dev_url: "https://github.com/YuLab-SMU/DOSE"
+      doi: "10.1093/bioinformatics/btu684"
+      licence: ["Artistic-2.0"]
+      identifier: biotools:DOSE
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id: 'simulation_id', chromosome: 'chr_number', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ]`
+    - enrichment_results:
+        type: file
+        description: RDS file containing enrichment results
+        pattern: "enrichment_results.rds"
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id: 'simulation_id', chromosome: 'chr_number', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ]`
+    - reads:
+        type: file
+        description: simulated reads in FASTA format
+        pattern: "*.fasta.gz"
+  - - meta3:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id: 'simulation_id', chromosome: 'chr_number', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ]`
+    - reads:
+        type: file
+        description: file containing differentially expressed genes
+        pattern: "de_genes.txt"
+output:
+  - valid_reads:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id: 'simulation_id', chromosome: 'chr_number', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ]`
+      - "*.fasta.gz":
+          type: file
+          description: validated reads in FASTA format
+          pattern: "*.fasta.gz"
+  - valid_de_genes:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id: 'simulation_id', chromosome: 'chr_number', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ]`
+      - "validated_de_genes.txt":
+          type: file
+          description: validated DE genes
+          pattern: "validated_de_genes.txt"
+  - validation_result:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id: 'simulation_id', chromosome: 'chr_number', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ]`
+      - "validation_result.txt":
+          type: file
+          description: File containing the result of the validation process, e.g (VALIDATION GOOD or VALIDATION NOT GOOD)
+          pattern: "validation_result.txt"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+authors:
+  - "@LorenzoS96"
+maintainers:
+  - "@LorenzoS96"

--- a/modules/local/rnaseqvalidation/meta.yml
+++ b/modules/local/rnaseqvalidation/meta.yml
@@ -39,7 +39,7 @@ input:
         description: |
           Groovy Map containing sample information
           e.g. `[ id: 'simulation_id', chromosome: 'chr_number', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ]`
-    - reads:
+    - de_genes:
         type: file
         description: file containing differentially expressed genes
         pattern: "de_genes.txt"
@@ -62,7 +62,7 @@ output:
             e.g. `[ id: 'simulation_id', chromosome: 'chr_number', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ]`
       - "validated_de_genes.txt":
           type: file
-          description: validated DE genes
+          description: file containing validated DE genes
           pattern: "validated_de_genes.txt"
   - validation_result:
       - meta:
@@ -72,12 +72,12 @@ output:
             e.g. `[ id: 'simulation_id', chromosome: 'chr_number', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ]`
       - "validation_result.txt":
           type: file
-          description: File containing the result of the validation process, e.g (VALIDATION GOOD or VALIDATION NOT GOOD)
+          description: file containing the result of the validation process, e.g (SIMULATION GOOD or SIMULATION NOT GOOD)
           pattern: "validation_result.txt"
   - versions:
       - versions.yml:
           type: file
-          description: File containing software versions
+          description: file containing software versions
           pattern: "versions.yml"
 authors:
   - "@LorenzoS96"

--- a/modules/local/rnaseqvalidation/tests/main.nf.test
+++ b/modules/local/rnaseqvalidation/tests/main.nf.test
@@ -1,0 +1,151 @@
+nextflow_process {
+
+    name "Test Process RNASEQVALIDATION"
+    script "../main.nf"
+    process "RNASEQVALIDATION"
+
+    tag "modules"
+    tag "modules_"
+    tag "rnaseqvalidation"
+
+test("validation - positive simulation") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ], // meta map
+                    file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/validation/positive_enrichment_results.rds', checkIfExists: true)
+                ]
+            input[1] = [
+                [ id: 'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ],
+                    [
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_01_1.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_01_2.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_02_1.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_02_2.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_03_1.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_03_2.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_04_1.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_04_2.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_05_1.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_05_2.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_06_1.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_06_2.fasta.gz', checkIfExists: true)
+                    ]
+                ]
+                input[2] = [
+                    [ id: 'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ], // meta map
+                    file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/validation/positive_deseq2_de_genes.txt', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.validation_result },
+                { assert process.out.valid_reads.get(0).get(1).first().endsWith('.fasta.gz') },
+                { assert process.out.valid_de_genes },
+                { assert process.out.versions }
+            )
+        }
+
+    }
+
+    test("validation - negative simulation") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ], // meta map
+                    file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/validation/negative_enrichment_results.rds', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id: 'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ],
+                    [
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_01_1.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_01_2.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_02_1.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_02_2.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_03_1.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_03_2.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_04_1.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_04_2.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_05_1.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_05_2.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_06_1.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_06_2.fasta.gz', checkIfExists: true)
+                    ]
+                ]
+                input[2] = [
+                    [ id: 'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ], // meta map
+                    file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/validation/negative_deseq2_de_genes.txt', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.validation_result },
+                { assert !process.out.valid_reads },
+                { assert !process.out.valid_de_genes },
+                { assert process.out.versions }
+            )
+        }
+
+    }
+
+    test("validation - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ], // meta map
+                    file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/validation/positive_enrichment_results.rds', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id: 'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ],
+                    [
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_01_1.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_01_2.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_02_1.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_02_2.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_03_1.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_03_2.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_04_1.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_04_2.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_05_1.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_05_2.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_06_1.fasta.gz', checkIfExists: true),
+                        file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_06_2.fasta.gz', checkIfExists: true)
+                    ]
+                ]
+                input[2] = [
+                    [ id: 'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ], // meta map
+                    file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/validation/positive_deseq2_de_genes.txt', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.validation_result },
+                { assert process.out.valid_reads },
+                { assert process.out.valid_reads.get(0).get(1).first().endsWith('.fasta.gz') },
+                { assert process.out.versions }
+            )
+        }
+
+    }
+
+}

--- a/modules/local/rnaseqvalidation/tests/main.nf.test
+++ b/modules/local/rnaseqvalidation/tests/main.nf.test
@@ -17,7 +17,7 @@ test("validation - positive simulation") {
                     [ id: 'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ], // meta map
                     file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/validation/positive_enrichment_results.rds', checkIfExists: true)
                 ]
-            input[1] = [
+                input[1] = [
                 [ id: 'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ],
                     [
                         file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/raw_reads/sample_01_1.fasta.gz', checkIfExists: true),


### PR DESCRIPTION
PR to add the rnaseqvalidation module. 
If the validation process gives positive results, I thaught to publish in a directory named `validated_reads` the symlinks to the original reads. The goal is to save space avoiding to copy the reads.
Additionally, the module also emits a file (`validated_de_genes.txt`) if the simulation is good.

nf-test working with:
- [x] nf-test test --profile conda
- [x] nf-test modules test --profile singularity
- [x]  nf-test modules test --profile docker

Closes #42 