### PR TITLE
simulate_rnaseq_reads subworkflow

### DIFF
--- a/modules/local/polyester/simulate/main.nf
+++ b/modules/local/polyester/simulate/main.nf
@@ -58,6 +58,7 @@ process POLYESTER_SIMULATE {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         polyester: \$(Rscript -e 'cat(as.character(packageVersion("polyester")))')
+        bioconductor-biostrings: \$(Rscript -e "cat(as.character(packageVersion('Biostrings')))")
     END_VERSIONS
     """
 
@@ -71,6 +72,7 @@ process POLYESTER_SIMULATE {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         polyester: \$(Rscript -e 'cat(as.character(packageVersion("polyester")))')
+        bioconductor-biostrings: \$(Rscript -e "cat(as.character(packageVersion('Biostrings')))")
     END_VERSIONS
     """
 }

--- a/subworkflows/local/simulate_rnaseq_reads/meta.yml
+++ b/subworkflows/local/simulate_rnaseq_reads/meta.yml
@@ -1,0 +1,136 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "simulate_rnaseq_reads"
+description: Simulates RNA-seq reads based on count matrices and fold changes
+keywords:
+  - RNA-seq
+  - simulation
+  - count matrices
+  - polyester
+components:
+  - countmatrices
+  - polyester_simulate
+input:
+  - ch_filtered_txfasta:
+      description: |
+        Channel with the filtered transcript fasta file
+        Structure: [ val(meta), path(filtered_txfasta) ]
+      structure:
+        - meta:
+            type: map
+            description: |
+              Groovy Map containing sample information
+              e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+        - filtered_txfasta:
+            type: file
+            description: transcriptome FASTA file containing transcripts from the specified chromosome
+            pattern: "gencode_transcripts_noversion.fasta"
+  - ch_filtered_gff3:
+      description: |
+        Channel with the filtered gff3 file
+        Structure: [ val(meta), path(filtered_gff3) ]
+      structure:
+        - meta:
+            type: map
+            description: |
+              Groovy Map containing sample information
+              e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+        - filtered_gff3:
+            type: file
+            description: RDS file containing transcripts from the specified chromosome
+            pattern: "filtered_gff3.rds"
+  - ch_genelists:
+      description: |
+        Channel containing those gene lists that should give an enrichment with EnrichGO
+        Structure: [ val(meta), path(genelists) ]
+      structure:
+        - meta:
+            type: map
+            description: |
+              Groovy Map containing sample information
+              e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+        - genelists:
+            type: file
+            description: RDS file containing those gene lists that should give an enrichment with EnrichGO
+            pattern: "valid_gene_lists.rds"
+  - ch_foldchange:
+      description: |
+        Channel containing fold changes
+        Structure: [ val(meta), path(foldchange) ]
+      structure:
+        - meta:
+            type: map
+            description: |
+              Groovy Map containing sample information
+              e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+        - foldchange:
+            type: file
+            description: fold change files
+            pattern: "*.rds"
+  - ch_genes_list_associations:
+      description: |
+        Channel containing the association between a specific list and its genes
+        Structure: [ val(meta), path(genes_list_associations) ]
+      structure:
+        - meta:
+            type: map
+            description: |
+              Groovy Map containing sample information
+              e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+        - genes_list_associations:
+            type: file
+            description: TSV file containing the association between a specific list and its genes
+            pattern: "list_gene_association.tsv"
+output:
+  - countMatrix:
+      description: |
+        Channel containing the count matrices associated to each gene list
+        Structure: [ val(meta), path(countMatrix) ]
+      structure:
+        - meta:
+            type: map
+            description: |
+              Groovy Map containing sample information
+              e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+        - countMatrix:
+            type: file
+            description: simulated count matrices
+            pattern: "countMatrix_*.rds"
+  - expectedLog2FC:
+      description: |
+        Channel containing the expected log2foldchange
+        Structure: [ val(meta), path(expectedLog2FC) ]
+      structure:
+        - meta:
+            type: map
+            description: |
+              Groovy Map containing sample information
+              e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+        - expectedLog2FC:
+            type: file
+            description: expected log2foldchange
+            pattern: "expected_*.rds"
+  - simreads:
+      description: |
+        Channel containing the simulated reads with a new meta containing also the DE genes
+        Structure: [ val(newmeta), path(simreads) ]
+      structure:
+        - newmeta:
+            type: map
+            description: |
+              Groovy Map containing sample information
+              e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3, genes: 'A,B,C' ]`
+        - simreads:
+            type: file
+            description: controls/cases simulated reads
+            pattern: "*.fasta.gz"
+  - versions:
+      description: |
+        Channel containing software versions file
+      structure:
+        - versions.yml:
+            type: file
+            description: file containing versions of the software used
+authors:
+  - "@LorenzoS96"
+maintainers:
+  - "@LorenzoS96"

--- a/subworkflows/local/simulate_rnaseq_reads/tests/main.nf.test
+++ b/subworkflows/local/simulate_rnaseq_reads/tests/main.nf.test
@@ -1,0 +1,68 @@
+nextflow_workflow {
+
+    name "Test Subworkflow SIMULATE_RNASEQ_READS"
+    script "../main.nf"
+    workflow "SIMULATE_RNASEQ_READS"
+
+    tag "subworkflows"
+    tag "subworkflows_"
+    tag "subworkflows/simulate_rnaseq_reads"
+    tag "countmatrices"
+    tag "polyester/simulate"
+
+    test("readsimulation - test") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.value([
+                    [ id:'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ], // meta map
+                    file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/countmatrices/gencode_transcripts_noversion_chr22.fasta', checkIfExists: true)
+                ])
+                input[1] = Channel.value([
+                    [ id:'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ], // meta map
+                    file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/countmatrices/transcriptData_chr22.rds', checkIfExists: true)
+                ])
+                input[2] = Channel.value([
+                    [ id:'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ], // meta map
+                    file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/countmatrices/small_gene_lists.rds', checkIfExists: true)
+                ])
+                input[3] = Channel.value([
+                    [ id:'simtest', chromosome:'chr22', coverage: '30', reps:'3', groups:'2', simthreshold: '0.3' ], // meta map
+                    file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/polyester/fcmatrix_testdata.rds', checkIfExists: true)
+                ])
+                input[4] = Channel.value([
+                    [ id:'simtest', chromosome:'chr22', coverage: '30', reps:'3', groups:'2', simthreshold: '0.3' ], // meta map
+                    file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/countmatrices/small_gene_lists.tsv', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                {
+                    assert workflow.out.countMatrix.every { meta, files ->
+                        files instanceof List &&
+                        files.every { it.toString().endsWith('.rds') }
+                    }
+                },
+                {
+                    assert workflow.out.simAnnords.every { meta, files ->
+                        files instanceof List &&
+                        files.every { it.toString().endsWith('.rds') }
+                    }
+                },
+                {
+                    assert workflow.out.simreads.every { meta, files ->
+                        files instanceof List &&
+                        files.every { it.toString().endsWith('.fasta.gz') } &&
+                        meta.containsKey('genes')
+                    }
+                },
+                { assert workflow.out.versions }
+            )
+        }
+    }
+}


### PR DESCRIPTION
PR to add the simulate_rnaseq_reads subworkflow. 
The key part of this subworkflow is the addition of the DE genes in the meta of the simulated reads. In this way, DE genes can be used in the following modules, when necessary.

nf-test working with:
- [x] nf-test test --profile conda
- [x] nf-test modules test --profile singularity
- [x]  nf-test modules test --profile docker

Closes #30 