### PR TITLE
adding dna validation module

### DIFF
--- a/modules/local/dnavalidation/environment.yml
+++ b/modules/local/dnavalidation/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - conda-forge::bash=5.2.21

--- a/modules/local/dnavalidation/main.nf
+++ b/modules/local/dnavalidation/main.nf
@@ -1,0 +1,55 @@
+
+process DNAVALIDATION {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    'oras://community.wave.seqera.io/library/bash:5.2.21--67f53ad0451dfdce' :
+    'community.wave.seqera.io/library/bash:5.2.21--5bc877f5b6cf0654' }"
+
+    input:
+    tuple val(meta) , path(vcf)
+    tuple val(meta2), path(reads)
+
+    output:
+    tuple val(meta), path("dna_${meta.simulatedvar}_validation")      , optional: true, emit: dna_validated_results
+    tuple val(meta), path("dna_${meta.simulatedvar}_validation/*.vcf"), optional: true, emit: vcf_file
+    path "versions.yml"                                                               , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def variant = meta.simulatedvar ?: ''
+    """
+    variantpos=\$(echo "${variant}" | cut -d"-" -f2)
+    if grep -q "\${variantpos}" ${vcf} && [ "${meta.simulatedvar}" = "${meta2.simulatedvar}" ]; then
+        mkdir -p dna_${variant}_validation
+        echo "${variant}" > dna_${variant}_validation/solution_${variant}.txt
+        cp ${vcf} dna_${variant}_validation/
+        cp ${reads} dna_${variant}_validation/
+    fi
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bash: \$(bash --version | sed -n 1p | sed 's/.*version //; s/ .*//')
+    END_VERSIONS
+    """
+
+    stub:
+    def variant = meta.simulatedvar ?: 'chr22-1234-A-T'
+    """
+    mkdir -p dna_${variant}_validation
+    touch dna_${variant}_validation/simulated_validated.vcf
+    touch dna_${variant}_validation/simulated_validated_read_1.fastq.gz
+    touch dna_${variant}_validation/simulated_validated_read_2.fastq.gz
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bash: 5.0.17
+    END_VERSIONS
+    """
+}

--- a/modules/local/dnavalidation/main.nf
+++ b/modules/local/dnavalidation/main.nf
@@ -1,4 +1,3 @@
-
 process DNAVALIDATION {
     tag "$meta.id"
     label 'process_single'

--- a/modules/local/dnavalidation/meta.yml
+++ b/modules/local/dnavalidation/meta.yml
@@ -8,11 +8,12 @@ keywords:
   - vcf
   - fastq
 tools:
-  - "dnavalidation":
-      description: "This module validates DNA sequences by checking if a simulated variant is present in the VCF file and copies the relevant files to a validation directory."
-      homepage: "https://github.com/lescai-teaching/eduomics"
-      documentation: "https://github.com/lescai-teaching/eduomics"
-      tool_dev_url: "https://github.com/lescai-teaching/eduomics"
+  - bash:
+      description: "GNU Bash is the shell, or command language interpreter, used for validating DNA sequences by checking if a simulated variant is present in the VCF file and copying the relevant files to a validation directory."
+      homepage: "https://www.gnu.org/software/bash/"
+      documentation: "https://www.gnu.org/software/bash/manual/"
+      licence: ["GPL-3.0-or-later"]
+      version: "5.2.21"
 
 input:
   - - meta:
@@ -24,11 +25,6 @@ input:
         type: file
         description: VCF file containing variant information
         pattern: "*.vcf"
-  - - meta2:
-        type: map
-        description: |
-          Groovy Map containing sample information for reads
-          e.g. [ id:'sample1', simulatedvar:'chr22-18078561-G-A' ]
     - reads:
         type: file
         description: FASTQ files containing sequencing reads
@@ -45,12 +41,6 @@ output:
           type: directory
           description: Directory containing validated DNA files
           pattern: "dna_*_validation"
-  - vcf_file:
-      - meta:
-          type: map
-          description: |
-            Groovy Map containing sample information
-            e.g. `[ id:'sample1', simulatedvar:'chr22-18078561-G-A' ]`
       - "dna_*_validation/*.vcf":
           type: file
           description: Validated VCF file

--- a/modules/local/dnavalidation/meta.yml
+++ b/modules/local/dnavalidation/meta.yml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "dnavalidation"
+description: This module validates DNA sequences by checking if a simulated variant is present in the VCF file and copies the relevant files to a validation directory.
+keywords:
+  - dna
+  - validation
+  - vcf
+  - fastq
+tools:
+  - "dnavalidation":
+      description: "This module validates DNA sequences by checking if a simulated variant is present in the VCF file and copies the relevant files to a validation directory."
+      homepage: "https://github.com/lescai-teaching/eduomics"
+      documentation: "https://github.com/lescai-teaching/eduomics"
+      tool_dev_url: "https://github.com/lescai-teaching/eduomics"
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1', simulatedvar:'chr22-18078561-G-A' ]`
+    - vcf:
+        type: file
+        description: VCF file containing variant information
+        pattern: "*.vcf"
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing sample information for reads
+          e.g. [ id:'sample1', simulatedvar:'chr22-18078561-G-A' ]
+    - reads:
+        type: file
+        description: FASTQ files containing sequencing reads
+        pattern: "*.fastq.gz"
+
+output:
+  - dna_validated_results:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', simulatedvar:'chr22-18078561-G-A' ]`
+      - "dna_*_validation":
+          type: directory
+          description: Directory containing validated DNA files
+          pattern: "dna_*_validation"
+  - vcf_file:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', simulatedvar:'chr22-18078561-G-A' ]`
+      - "dna_*_validation/*.vcf":
+          type: file
+          description: Validated VCF file
+          pattern: "dna_*_validation/*.vcf"
+  - versions:
+      - "versions.yml":
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+
+authors:
+  - "@DavideBag"
+maintainers:
+  - "@DavideBag"

--- a/modules/local/dnavalidation/tests/main.nf.test
+++ b/modules/local/dnavalidation/tests/main.nf.test
@@ -1,0 +1,78 @@
+nextflow_process {
+
+    name "Test Process DNAVALIDATION"
+    script "../main.nf"
+    process "DNAVALIDATION"
+
+    tag "modules"
+    tag "modules_nf_core"
+    tag "dnavalidation"
+
+    test("Should validate DNA when variant is found") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test1', simulatedvar:'chr22-34449622-G-A'],
+                    file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/result_ann_test.vcf")
+                ]
+                input[1] = [
+                    [ id:'test1', simulatedvar:'chr22-34449622-G-A'  ],
+                    [ file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_1.fastq.gz"), file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_2.fastq.gz") ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert process.out.dna_validated_results.size() == 1
+        }
+    }
+
+    test("Should not validate DNA when variant is not found") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test2', simulatedvar:'CIAONELORENZO' ],
+                    file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/result_ann_test.vcf")
+                ]
+                input[1] = [
+                    [ id:'test2' ],
+                    [ file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_1.fastq.gz"), file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_2.fastq.gz") ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert process.out.dna_validated_results.isEmpty()
+        }
+    }
+
+    test("Stub should work correctly") {
+        options "-stub"
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test_stub', simulatedvar:'chr22-1234-A-T' ],
+                    file("dummy.vcf")
+                ]
+                input[1] = [
+                    [ id:'test_stub' ],
+                    [ file("dummy_1.fastq.gz"), file("dummy_2.fastq.gz") ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert process.out.dna_validated_results.size() == 1
+            assert path(process.out.dna_validated_results.get(0).get(1)).list().size() == 3
+        }
+    }
+}

--- a/modules/local/dnavalidation/tests/main.nf.test
+++ b/modules/local/dnavalidation/tests/main.nf.test
@@ -13,12 +13,14 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test1', simulatedvar:'chr22-34449622-G-A'],
-                    file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/result_ann_test.vcf")
-                ]
-                input[1] = [
-                    [ id:'test1', simulatedvar:'chr22-34449622-G-A'  ],
-                    [ file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_1.fastq.gz"), file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_2.fastq.gz") ]
+                    [ id:'test1', simulatedvar:'chr22-34449622-G-A' ],
+                    file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/result_ann_test.vcf"),
+                    [
+                        file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_case_1.fastq.gz"),
+                        file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_case_2.fastq.gz"),
+                        file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_control_1.fastq.gz"),
+                        file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_control_2.fastq.gz")
+                    ]
                 ]
                 """
             }
@@ -26,7 +28,13 @@ nextflow_process {
 
         then {
             assert process.success
-            assert process.out.dna_validated_results.size() == 1
+            def dir = new File(process.out.dna_validated_results[0][1])
+            def files = dir.listFiles() as List
+            assert files.count { it.name.endsWith('.vcf') } == 1
+            assert files.count { it.name.endsWith('.txt') } == 1
+            assert files.count { it.name.endsWith('.fastq.gz') } == 4
+            assert files.size() == 6  // 1 solution file, 1 VCF, 4 FASTQ.GZ
+            assert process.out.versions
         }
     }
 
@@ -35,12 +43,14 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test2', simulatedvar:'CIAONELORENZO' ],
-                    file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/result_ann_test.vcf")
-                ]
-                input[1] = [
-                    [ id:'test2' ],
-                    [ file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_1.fastq.gz"), file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_2.fastq.gz") ]
+                    [ id:'test2', simulatedvar:'LOLLOLOLLO' ],
+                    file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/result_ann_test.vcf"),
+                    [
+                        file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_case_1.fastq.gz"),
+                        file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_case_2.fastq.gz"),
+                        file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_control_1.fastq.gz"),
+                        file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_control_2.fastq.gz")
+                    ]
                 ]
                 """
             }
@@ -49,6 +59,7 @@ nextflow_process {
         then {
             assert process.success
             assert process.out.dna_validated_results.isEmpty()
+            assert process.out.versions
         }
     }
 
@@ -59,11 +70,13 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test_stub', simulatedvar:'chr22-1234-A-T' ],
-                    file("dummy.vcf")
-                ]
-                input[1] = [
-                    [ id:'test_stub' ],
-                    [ file("dummy_1.fastq.gz"), file("dummy_2.fastq.gz") ]
+                    file("dummy.vcf"),
+                    [
+                        file("dummy_case_1.fastq.gz"),
+                        file("dummy_case_2.fastq.gz"),
+                        file("dummy_control_1.fastq.gz"),
+                        file("dummy_control_2.fastq.gz")
+                    ]
                 ]
                 """
             }
@@ -71,8 +84,13 @@ nextflow_process {
 
         then {
             assert process.success
-            assert process.out.dna_validated_results.size() == 1
-            assert path(process.out.dna_validated_results.get(0).get(1)).list().size() == 3
+            def dir = new File(process.out.dna_validated_results[0][1])
+            def files = dir.listFiles() as List
+            assert files.count { it.name.endsWith('.vcf') } == 1
+            assert files.count { it.name.endsWith('.txt') } == 1
+            assert files.count { it.name.endsWith('.fastq.gz') } == 4
+            assert files.size() == 6  // 1 solution file, 1 VCF, 4 FASTQ.GZ
+            assert process.out.versions
         }
     }
 }


### PR DESCRIPTION
Adding DNA VALIDATION module. tested with conda, docker and singularity. Module takes vcf and reads as input. 
It extracts the variant from the VCF metadata. It checks for the presence of the variant in the VCF. If it is found, it checks whether the same variant is present in the reads metadata. 
It creates a folder named dna_variantname_validated and places the following inside:

1) the VCF file for possible analysis with SnpEff
2) the reads coming from SimuScop
3) a solution.txt file containing the name of the variant

else it discards vcf.