### PR TITLE
Adjustments RNAseq subworkflows

### DIFF
--- a/assets/test.csv
+++ b/assets/test.csv
@@ -1,0 +1,2 @@
+id,type,chromosome,coverage,capture,reps,groups,simthreshold
+simulation2,rna,chr22,30,,3,2,0.3

--- a/assets/test.csv
+++ b/assets/test.csv
@@ -1,2 +1,0 @@
-id,type,chromosome,coverage,capture,reps,groups,simthreshold
-simulation2,rna,chr22,30,,3,2,0.3

--- a/bin/count_matrices.R
+++ b/bin/count_matrices.R
@@ -13,13 +13,13 @@ coverage <- as.numeric(argv[1])
 replica <- as.numeric(argv[2])
 group <- as.numeric(argv[3])
 filtered_txfasta <- argv[4]
-filtered_gff3 <- argv[5]
+transcriptData <- argv[5]
 geneList <- argv[6]
 
 
 #### Load the input files ####
 fasta_annotated = readDNAStringSet(filtered_txfasta)
-annotation_data = readRDS(filtered_gff3)
+annotation_data = readRDS(transcriptData)
 geneList = readRDS(geneList)
 
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -92,7 +92,7 @@ process {
             if (meta.type == "dna") {
                 "scenario_${variant}"
             } else {
-                def genePrefix = genes.take(5).replaceAll(',', '_')
+                def genePrefix = genes.split(',').take(5).join('_')
                 "scenario_${genePrefix}"
             }
         }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -84,6 +84,20 @@ process {
         memory = { 32.GB * task.attempt }
     }
 
+    withName: 'AISCENARIOS' {
+        ext.prefix = {
+            def variant = meta.simulatedvar ?: ''
+            def genes = meta.genes ?: ''
+
+            if (meta.type == "dna") {
+                "scenario_${variant}"
+            } else {
+                def genePrefix = genes.take(5).replaceAll(',', '_')
+                "scenario_${genePrefix}"
+            }
+        }
+    }
+
 }
 
 env {

--- a/main.nf
+++ b/main.nf
@@ -192,7 +192,7 @@ output {
 
     rnasimulation {
         path { meta, files ->
-            def simfolder = meta.genes.take(16)
+            def simfolder = meta.genes.split(',').take(5).join('_')
             "${params.outdir}/rna_simulations/${meta.id}/${simfolder}"
         }
     }
@@ -203,13 +203,14 @@ output {
         }
     }
 
+
     scenario {
         path { meta, text ->
             if (meta.type == "dna"){
                 "${params.outdir}/dna_simulations/${meta.id}/${meta.simulatedvar}"
             }
             else {
-                def simfolder = meta.genes.take(5).replaceAll(',', '_')
+                def simfolder = meta.genes.split(',').take(5).join('_')
                 "${params.outdir}/rna_simulations/${meta.id}/${simfolder}"
             }
         }

--- a/main.nf
+++ b/main.nf
@@ -209,7 +209,7 @@ output {
                 "${params.outdir}/dna_simulations/${meta.id}/${meta.simulatedvar}"
             }
             else {
-                def simfolder = meta.genes.take(16)
+                def simfolder = meta.genes.take(5).replaceAll(',', '_')
                 "${params.outdir}/rna_simulations/${meta.id}/${simfolder}"
             }
         }

--- a/modules/local/countmatrices/main.nf
+++ b/modules/local/countmatrices/main.nf
@@ -9,7 +9,7 @@ process COUNTMATRICES {
 
     input:
     tuple val(meta),  path(filtered_txfasta)
-    tuple val(meta2), path(filtered_transcriptData)
+    tuple val(meta2), path(transcriptData)
     tuple val(meta3), path(geneLists)
 
     output:
@@ -32,7 +32,7 @@ process COUNTMATRICES {
         '${simreps}' \\
         '${simgroups}' \\
         '${filtered_txfasta}' \\
-        '${filtered_transcriptData}' \\
+        '${transcriptData}' \\
         '${geneLists}'
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/deanalysis/meta.yml
+++ b/modules/local/deanalysis/meta.yml
@@ -56,7 +56,7 @@ input:
     - transcriptData:
         type: file
         description: RDS containing transcript data emitted by the subsetgff module
-        pattern: "*.rds"
+        pattern: "transcript_data.rds"
 output:
   - deseq2_results:
       - meta:

--- a/modules/local/subsetfastatx/main.nf
+++ b/modules/local/subsetfastatx/main.nf
@@ -9,7 +9,7 @@ process SUBSETFASTATX {
 
     input:
     path(txfasta)
-    tuple val(meta), path(filtered_transcript_data)
+    tuple val(meta), path(transcript_data)
 
     output:
     tuple val(meta), path ("gencode_transcripts_novers_*.fasta"), emit: filtered_txfasta
@@ -24,7 +24,7 @@ process SUBSETFASTATX {
     def prefix = task.ext.prefix ?: "${meta.id}"
 
     """
-    subset_fastatx.R ${meta.chromosome} ${txfasta} ${filtered_transcript_data}
+    subset_fastatx.R ${meta.chromosome} ${txfasta} ${transcript_data}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/subsetfastatx/meta.yml
+++ b/modules/local/subsetfastatx/meta.yml
@@ -31,10 +31,10 @@ input:
         description: |
           Groovy Map containing sample information
           e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
-    - filtered_transcript_data:
+    - transcript_data:
         type: file
         description: RDS file containing transcript data from the simulated chromosome
-        pattern: "filtered_transcript_data.rds"
+        pattern: "transcript_data.rds"
 output:
   - filtered_txfasta:
       - meta:

--- a/modules/local/subsetfastatx/meta.yml
+++ b/modules/local/subsetfastatx/meta.yml
@@ -42,10 +42,10 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
-      - "gencode_transcripts_noversion.fasta":
+      - "gencode_transcripts_novers_simchr.fasta":
           type: file
           description: subset FASTA file containing transcripts from the simulated chromosome
-          pattern: "gencode_transcripts_noversion.fasta"
+          pattern: "gencode_transcripts_novers_simchr.fasta"
   - subsetfastatx_parsing_log:
       - meta:
           type: file

--- a/modules/local/subsetgff/main.nf
+++ b/modules/local/subsetgff/main.nf
@@ -15,7 +15,7 @@ process SUBSETGFF {
     tuple val(meta), path("filtered_annotation.gff3")        , emit: filtered_annotation
     tuple val(meta), path("valid_gene_lists.rds")            , emit: geneLists
     tuple val(meta), path("list_gene_association.tsv")       , emit: genes_list_association
-    tuple val(meta), path("filtered_transcript_data.rds")    , emit: filtered_transcript_data
+    tuple val(meta), path("transcript_data.rds")             , emit: transcript_data
     tuple val(meta), path("subsetgff_parsing_log.txt")       , emit: subsetgff_parsing_log
     path "versions.yml"                                      , emit: versions
 

--- a/modules/local/subsetgff/meta.yml
+++ b/modules/local/subsetgff/meta.yml
@@ -126,16 +126,16 @@ output:
           type: file
           description: TSV file containing the association between genes and the corrisponding list
           pattern: "list_gene_association.tsv"
-  - filtered_transcript_data:
+  - transcript_data:
       - meta:
           type: file
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
-      - "filtered_transcript_data.rds":
+      - "transcript_data.rds":
           type: file
           description: RDS file containing transcript data from the simulated chromosome
-          pattern: "filtered_transcript_data.rds"
+          pattern: "transcript_data.rds"
   - subsetgff_parsing_log:
       - meta:
           type: file

--- a/subworkflows/local/prepare_rna_genome/main.nf
+++ b/subworkflows/local/prepare_rna_genome/main.nf
@@ -1,14 +1,16 @@
-include { SUBSETFASTATX      } from '../../../modules/local/subsetfastatx/main'
-include { SUBSETGFF          } from '../../../modules/local/subsetgff/main'
-include { SALMON_INDEX       } from '../../../modules/nf-core/salmon/index/main'
+include { SUBSETFASTATX                              } from '../../../modules/local/subsetfastatx/main'
+include { SUBSETGFF                                  } from '../../../modules/local/subsetgff/main'
+include { SALMON_INDEX                               } from '../../../modules/nf-core/salmon/index/main'
+include { SAMTOOLS_FAIDX as SAMTOOLS_FAIDX_SUBSET    } from '../../../modules/nf-core/samtools/faidx/main'
+
 
 workflow PREPARE_RNA_GENOME {
 
     take:
-    ch_meta    // channel: [ val(meta)     ]
-    ch_gff3    // channel: [ path(gff3)    ]
-    ch_txfasta // channel: [ path(txfasta) ]
-    ch_fasta   // channel: [ path(genomefasta) ]
+    ch_meta          // channel: [ val(meta)         ]
+    ch_gff3          // channel: [ path(gff3)        ]
+    ch_txfasta       // channel: [ path(txfasta)     ]
+    ch_genomefasta   // channel: [ path(genomefasta) ]
 
     main:
 
@@ -23,30 +25,43 @@ workflow PREPARE_RNA_GENOME {
     ch_versions = ch_versions.mix(SUBSETFASTATX.out.versions)
     ch_log      = ch_log.mix(SUBSETFASTATX.out.subsetfastatx_parsing_log)
 
-    // Remove the meta from the filtered txfasta
+    // Add the meta to the genome fasta
+    // Samtools faidx requires an input with the meta
+    ch_genomefasta_with_meta = ch_meta.combine(ch_genomefasta)
+        .map { meta, fasta -> [meta, fasta] }
+
+    SAMTOOLS_FAIDX_SUBSET ( ch_genomefasta_with_meta, [[],[]], [] )
+    ch_versions = ch_versions.mix(SAMTOOLS_FAIDX_SUBSET.out.versions)
+
+    // Remove the meta from the filtered txfasta and from the filtered genome fasta
     // Salmon index requires inputs without a meta
     ch_filtered_txfasta_nometa = SUBSETFASTATX.out.filtered_txfasta
         .map { meta, fasta -> fasta }
 
-    SALMON_INDEX ( ch_fasta, ch_filtered_txfasta_nometa )
+    ch_filtered_genomefasta_nometa = SAMTOOLS_FAIDX_SUBSET.out.fa
+        .map { meta, fasta -> fasta }
+
+    SALMON_INDEX ( ch_filtered_genomefasta_nometa, ch_filtered_txfasta_nometa )
     ch_versions = ch_versions.mix(SALMON_INDEX.out.versions)
 
     ch_rna_bundle = SUBSETFASTATX.out.filtered_txfasta
         .join(SUBSETGFF.out.filtered_annotation)
+        .join(SAMTOOLS_FAIDX_SUBSET.out.fa)
         .combine(SALMON_INDEX.out.index)
         .map { it ->
             [it[0], it[1..-1]]
         }
 
     emit:
-    filtered_annotation      = SUBSETGFF.out.filtered_annotation.collect()      // channel: [ val(meta), path(filtered_annotation)                      ]
-    gene_lists               = SUBSETGFF.out.geneLists                          // channel: [ val(meta), path(geneLists)                                ]
-    gene_list_association    = SUBSETGFF.out.genes_list_association             // channel: [ val(meta), path(gene_list_association)                    ]
-    filtered_transcript_data = SUBSETGFF.out.filtered_transcript_data.collect() // channel: [ val(meta), path(filtered_transcript_data)                 ]
-    filtered_txfasta         = SUBSETFASTATX.out.filtered_txfasta.collect()     // channel: [ val(meta), path(filtered_txfasta)                         ]
-    txfasta_index            = SALMON_INDEX.out.index.collect()                 // channel: [ path(salmon_index)                                        ]
-    log_files                = ch_log                                           // channel: [ val(meta), path(log_files)                                ]
-    rna_bundle               = ch_rna_bundle.collect()                          // channel: [ val(meta), [path(txfasta), path(gff3), path(salmonindex)] ]
-    versions                 = ch_versions                                      // channel: [ versions.yml                                              ]
+    filtered_annotation      = SUBSETGFF.out.filtered_annotation.collect()      // channel: [ val(meta), path(filtered_annotation)                                                                     ]
+    gene_lists               = SUBSETGFF.out.geneLists                          // channel: [ val(meta), path(geneLists)                                                                               ]
+    gene_list_association    = SUBSETGFF.out.genes_list_association             // channel: [ val(meta), path(gene_list_association)                                                                   ]
+    filtered_transcript_data = SUBSETGFF.out.filtered_transcript_data.collect() // channel: [ val(meta), path(filtered_transcript_data)                                                                ]
+    filtered_txfasta         = SUBSETFASTATX.out.filtered_txfasta.collect()     // channel: [ val(meta), path(filtered_txfasta)                                                                        ]
+    filtered_genomefasta     = SAMTOOLS_FAIDX_SUBSET.out.fa.collect()           // channel: [ val(meta), path(filtered_genomefasta)                                                                    ]
+    txfasta_index            = SALMON_INDEX.out.index.collect()                 // channel: [ path(salmon_index)                                                                                       ]
+    log_files                = ch_log                                           // channel: [ val(meta), path(log_files)                                                                               ]
+    rna_bundle               = ch_rna_bundle.collect()                          // channel: [ val(meta), [path(filtered_txfasta), path(filtered_gff3), path(gfiltered_genomefasta), path(salmonindex)] ]
+    versions                 = ch_versions                                      // channel: [ versions.yml                                                                                             ]
 }
 

--- a/subworkflows/local/prepare_rna_genome/main.nf
+++ b/subworkflows/local/prepare_rna_genome/main.nf
@@ -21,7 +21,7 @@ workflow PREPARE_RNA_GENOME {
     ch_versions = ch_versions.mix(SUBSETGFF.out.versions)
     ch_log      = ch_log.mix(SUBSETGFF.out.subsetgff_parsing_log)
 
-    SUBSETFASTATX ( ch_txfasta, SUBSETGFF.out.filtered_transcript_data )
+    SUBSETFASTATX ( ch_txfasta, SUBSETGFF.out.transcript_data )
     ch_versions = ch_versions.mix(SUBSETFASTATX.out.versions)
     ch_log      = ch_log.mix(SUBSETFASTATX.out.subsetfastatx_parsing_log)
 
@@ -56,12 +56,12 @@ workflow PREPARE_RNA_GENOME {
     filtered_annotation      = SUBSETGFF.out.filtered_annotation.collect()      // channel: [ val(meta), path(filtered_annotation)                                                                     ]
     gene_lists               = SUBSETGFF.out.geneLists                          // channel: [ val(meta), path(geneLists)                                                                               ]
     gene_list_association    = SUBSETGFF.out.genes_list_association             // channel: [ val(meta), path(gene_list_association)                                                                   ]
-    filtered_transcript_data = SUBSETGFF.out.filtered_transcript_data.collect() // channel: [ val(meta), path(filtered_transcript_data)                                                                ]
+    transcript_data          = SUBSETGFF.out.transcript_data.collect()          // channel: [ val(meta), path(transcript_data)                                                                         ]
     filtered_txfasta         = SUBSETFASTATX.out.filtered_txfasta.collect()     // channel: [ val(meta), path(filtered_txfasta)                                                                        ]
     filtered_genomefasta     = SAMTOOLS_FAIDX_SUBSET.out.fa.collect()           // channel: [ val(meta), path(filtered_genomefasta)                                                                    ]
     txfasta_index            = SALMON_INDEX.out.index.collect()                 // channel: [ path(salmon_index)                                                                                       ]
     log_files                = ch_log                                           // channel: [ val(meta), path(log_files)                                                                               ]
-    rna_bundle               = ch_rna_bundle.collect()                          // channel: [ val(meta), [path(filtered_txfasta), path(filtered_gff3), path(filtered_genomefasta), path(salmonindex)] ]
+    rna_bundle               = ch_rna_bundle.collect()                          // channel: [ val(meta), [path(filtered_txfasta), path(filtered_gff3), path(filtered_genomefasta), path(salmonindex)]  ]
     versions                 = ch_versions                                      // channel: [ versions.yml                                                                                             ]
 }
 

--- a/subworkflows/local/prepare_rna_genome/main.nf
+++ b/subworkflows/local/prepare_rna_genome/main.nf
@@ -61,7 +61,7 @@ workflow PREPARE_RNA_GENOME {
     filtered_genomefasta     = SAMTOOLS_FAIDX_SUBSET.out.fa.collect()           // channel: [ val(meta), path(filtered_genomefasta)                                                                    ]
     txfasta_index            = SALMON_INDEX.out.index.collect()                 // channel: [ path(salmon_index)                                                                                       ]
     log_files                = ch_log                                           // channel: [ val(meta), path(log_files)                                                                               ]
-    rna_bundle               = ch_rna_bundle.collect()                          // channel: [ val(meta), [path(filtered_txfasta), path(filtered_gff3), path(gfiltered_genomefasta), path(salmonindex)] ]
+    rna_bundle               = ch_rna_bundle.collect()                          // channel: [ val(meta), [path(filtered_txfasta), path(filtered_gff3), path(filtered_genomefasta), path(salmonindex)] ]
     versions                 = ch_versions                                      // channel: [ versions.yml                                                                                             ]
 }
 

--- a/subworkflows/local/prepare_rna_genome/meta.yml
+++ b/subworkflows/local/prepare_rna_genome/meta.yml
@@ -81,20 +81,20 @@ output:
             type: file
             description: TSV file containing the association between a specific list and its genes (required in the following steps)
             pattern: "list_gene_association.tsv"
-  - filtered_transcript_data:
+  - transcript_data:
       description: |
         Channel containing the filtered transcript data from the simulated chromosome
-        Structure: [ val(meta), path(filtered_transcript_data) ]
+        Structure: [ val(meta), path(transcript_data) ]
       structure:
         - meta:
             type: map
             description: |
               Groovy Map containing sample information
               e.g. `[ id:'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
-        - filtered_transcript_data:
+        - transcript_data:
             type: file
             description: RDS containing filtered transcript data from the simulated chromosome
-            pattern: "filtered_transcript_data.rds"
+            pattern: "transcript_data.rds"
   - filtered_txfasta:
       description: |
         Channel containing the filtered txfasta file with the transcripts from the simulated chromosome

--- a/subworkflows/local/prepare_rna_genome/meta.yml
+++ b/subworkflows/local/prepare_rna_genome/meta.yml
@@ -6,11 +6,13 @@ keywords:
   - genome
   - fasta
   - gff
+  - samtools
   - salmon
   - index
 components:
   - subsetfastatx
   - subsetgff
+  - samtools/faidx
   - salmon/index
 input:
   - ch_meta:
@@ -30,10 +32,10 @@ input:
         The input channel containing the transcript FASTA file
         Structure: [ path(txfasta) ]
       pattern: "*.{fa,fasta}"
-  - ch_fasta:
+  - ch_genomefasta:
       type: file
       description: |
-        The input channel containing the FASTA file
+        The input channel containing the genome FASTA file
         Structure: [ path(fasta) ]
       pattern: "*.{fa,fasta}"
 output:
@@ -46,7 +48,7 @@ output:
             type: map
             description: |
               Groovy Map containing sample information
-              e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+              e.g. `[ id:'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
         - filtered_annotation:
             type: file
             description: filtered GFF3 file with the transcripts from the simulated chromosome
@@ -60,7 +62,7 @@ output:
             type: map
             description: |
               Groovy Map containing sample information
-              e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+              e.g. `[ id:'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
         - gene_lists:
             type: file
             description: RDS file containing gene lists that should give an enrichment
@@ -74,7 +76,7 @@ output:
             type: map
             description: |
               Groovy Map containing sample information
-              e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+              e.g. `[ id:'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
         - gene_list_association:
             type: file
             description: TSV file containing the association between a specific list and its genes (required in the following steps)
@@ -88,7 +90,7 @@ output:
             type: map
             description: |
               Groovy Map containing sample information
-              e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+              e.g. `[ id:'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
         - filtered_transcript_data:
             type: file
             description: RDS containing filtered transcript data from the simulated chromosome
@@ -102,17 +104,45 @@ output:
             type: map
             description: |
               Groovy Map containing sample information
-              e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+              e.g. `[ id:'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
         - filtered_txfasta:
             type: file
             description: filtered FASTA file with the transcripts from the simulated chromosome
-            pattern: "gencode_transcripts_noversion.fasta"
+            pattern: "gencode_transcripts_novers_simchr.fasta"
+  - filtered_genomefasta:
+      description: |
+        Channel containing the filtered genome FASTA file with the simulated chromosome
+        Structure: [ val(meta), path(filtered_genomefasta) ]
+      structure:
+        - meta:
+            type: map
+            description: |
+              Groovy Map containing sample information
+              e.g. `[ id:'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+        - filtered_genomefasta:
+            type: file
+            description: filtered genome FASTA file with the simulated chromosome
+            pattern: "simid_simchr.fasta"
   - txfasta_index:
       type: directory
       description: |
         Channel containing Salmon index directory
         Structure: [ path(salmon_index) ]
       pattern: "salmon_index"
+  - rna_bundle:
+      description: |
+        Channel containing the references from the simulated chromosome
+        Structure: [ val(meta), [path(filtered_txfasta), path(filtered_gff3), path(filtered_genomefasta), path(salmonindex)] ]
+      structure:
+        - meta:
+            type: map
+            description: |
+              Groovy Map containing sample information
+              e.g. `[ id:'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+        - rna_bundle:
+            type: file
+            description: references from the simulated chromosome
+            pattern: "*.fasta, *gff3, salmon"
   - log_files:
       description: |
         Channel containing log files from the modules subsetfastatx and subsetgff
@@ -122,7 +152,7 @@ output:
             type: map
             description: |
               Groovy Map containing sample information
-              e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
+              e.g. `[ id:'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
         - log_files:
             type: file
             description: TXT file containing containing parsing and analysis information

--- a/subworkflows/local/prepare_rna_genome/tests/main.nf.test
+++ b/subworkflows/local/prepare_rna_genome/tests/main.nf.test
@@ -11,6 +11,7 @@ nextflow_workflow {
     tag "subworkflows/prepare_rna_genome"
     tag "subsetfastatx"
     tag "subsetgff"
+    tag "samtools/faidx"
     tag "salmon"
     tag "salmon/index"
 
@@ -21,10 +22,10 @@ nextflow_workflow {
 
             workflow {
                 """
-                input[0] = Channel.of([ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ])
+                input[0] = Channel.of([ id:'simtest', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ])
                 input[1] = Channel.value(file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/subsetfastatx/gencode_chr21_chr22_v47.gff3', checkIfExists: true))
                 input[2] = Channel.value(file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/subsetfastatx/gencode_transcripts_noversion_chr21_chr22.fasta', checkIfExists: true))
-                input[3] = Channel.value(file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/whole_chr22/Homo_sapiens.GRCh38.dna.chromosome.22.fa', checkIfExists: true))
+                input[3] = Channel.value(file('https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/chr22_q11-21_GRCh38.fasta', checkIfExists: true))
                 """
             }
         }
@@ -37,11 +38,12 @@ nextflow_workflow {
                 { assert workflow.out.gene_list_association.get(0).get(1).endsWith('.tsv') },
                 { assert workflow.out.filtered_transcript_data.get(0).get(1).endsWith('.rds') },
                 { assert workflow.out.filtered_txfasta.get(0).get(1).endsWith('.fasta') },
+                { assert workflow.out.filtered_genomefasta.get(0).get(1).endsWith('.fasta') },
                 {
-                    def indexDir = path(workflow.out.txfasta_index[0]).toFile()
-                    assert indexDir.exists()
-                    assert indexDir.isDirectory()
-                    assert indexDir.listFiles().size() > 0
+                    def salmonIndexPath = workflow.out.txfasta_index[0][0]
+                    def salmonIndexFile = path(salmonIndexPath).toFile()
+                    assert salmonIndexFile.exists()
+                    assert salmonIndexFile.isDirectory()
                 },
                 { assert workflow.out.log_files.collect { it[1] }.every { it.endsWith('.txt') } }
             )

--- a/subworkflows/local/quantify_deanalysis_enrich_validate/main.nf
+++ b/subworkflows/local/quantify_deanalysis_enrich_validate/main.nf
@@ -13,11 +13,13 @@ workflow QUANTIFY_DEANALYSIS_ENRICH_VALIDATE {
     ch_filteredtxfasta            // channel: [ val(meta), path(filteredtxfasta)                   ]
     ch_alignment_mode             // value  : [ boolean                                            ]
     ch_libtype                    // value  : [ val(libtype)                                       ]
-    ch_filtered_transcriptData    // channel: [ val(meta), path(filtered_transcriptData)           ]
+    ch_transcriptData             // channel: [ val(meta), path(transcriptData)                    ]
 
     main:
 
     ch_versions = Channel.empty()
+
+    ch_simreads.dump(tag: "rna simreads")
 
     // Modify `meta.id` to make it unique for each sample based on filenames
     ch_simreads_modified = ch_simreads.map{ m, files ->
@@ -65,7 +67,7 @@ workflow QUANTIFY_DEANALYSIS_ENRICH_VALIDATE {
     ch_deanalysis_input.dump(tag: 'quant dirs')
 
     // Run differential expression analysis
-    DEANALYSIS ( ch_deanalysis_input, ch_filtered_transcriptData )
+    DEANALYSIS ( ch_deanalysis_input, ch_transcriptData )
     ch_versions = ch_versions.mix(DEANALYSIS.out.versions)
 
     // Extract only deseq2_results.tsv for enrichment module

--- a/subworkflows/local/quantify_deanalysis_enrich_validate/meta.yml
+++ b/subworkflows/local/quantify_deanalysis_enrich_validate/meta.yml
@@ -80,10 +80,10 @@ input:
         - libtype:
             type: string
             description: library type based on strandedness
-  - ch_filtered_transcriptData:
+  - ch_transcriptData:
       description: |
         Channel containing the transcript data from the simulated chromosome
-        Structure: [ val(meta), path(filtered_transcriptData) ]
+        Structure: [ val(meta), path(transcriptData) ]
       structure:
         - meta:
             type: map
@@ -93,7 +93,7 @@ input:
         - filtered_transcriptData:
             type: file
             description: RDS file containing transcript data from the simulated chromosome
-            pattern: "filtered_transcriptData.rds"
+            pattern: "transcriptData.rds"
 output:
   - salmon_results:
       description: |

--- a/subworkflows/local/quantify_deanalysis_enrich_validate/tests/main.nf.test
+++ b/subworkflows/local/quantify_deanalysis_enrich_validate/tests/main.nf.test
@@ -45,15 +45,10 @@ nextflow_workflow {
                         'https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/raw_reads_enrichment/sample_06_2.fasta.gz'
                     ]
                 ]
-                input[0] = Channel
-                    .fromList(sample_urls.entrySet())
-                    .map { entry ->
-                        def sample_id = entry.key
-                        def urls = entry.value
-                        def meta = [ id: 'simtest', chromosome: 'chr22', reps: 3, groups: 2, genes: 'A,B,C' ]
-                        def files = urls.collect { file(it) }
-                        [meta, files]
-                    }
+                input[0] = Channel.value([
+                    [ id: 'simtest', chromosome: 'chr22', reps: 3, groups: 2, genes: 'A,B,C' ],
+                    sample_urls.values().flatten().collect { file(it) }
+                ])
                 def index_urls = [
                     'https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/chr22_transcripts_index/complete_ref_lens.bin',
                     'https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/rnaseq/salmonquantify/chr22_transcripts_index/ctable.bin',

--- a/subworkflows/local/simulate_rnaseq_reads/main.nf
+++ b/subworkflows/local/simulate_rnaseq_reads/main.nf
@@ -5,9 +5,9 @@ workflow SIMULATE_RNASEQ_READS {
 
     take:
     ch_filtered_txfasta            // channel: [ val(meta), path(filtered_txfasta)        ]
-    ch_filtered_transcriptData     // channel: [ val(meta), path(filtered_transcriptData) ]
+    ch_transcriptData              // channel: [ val(meta), path(transcriptData)          ]
     ch_genelists                   // channel: [ val(meta), path(genelists)               ]
-    ch_gene_list_association       // channel: [ val(meta), path(gene_list_association)     ]
+    ch_gene_list_association       // channel: [ val(meta), path(gene_list_association)   ]
 
     main:
 
@@ -16,7 +16,7 @@ workflow SIMULATE_RNASEQ_READS {
     ch_gene_list_association.dump(tag: 'gene list association')
 
     // Generate count matrices
-    COUNTMATRICES(ch_filtered_txfasta, ch_filtered_transcriptData, ch_genelists)
+    COUNTMATRICES(ch_filtered_txfasta, ch_transcriptData, ch_genelists)
     ch_versions = ch_versions.mix(COUNTMATRICES.out.versions)
 
     // Build gene map

--- a/subworkflows/local/simulate_rnaseq_reads/meta.yml
+++ b/subworkflows/local/simulate_rnaseq_reads/meta.yml
@@ -24,20 +24,20 @@ input:
             type: file
             description: transcriptome FASTA file containing transcripts from the simulated chromosome
             pattern: "gencode_transcripts_noversion.fasta"
-  - ch_filtered_transcriptData:
+  - ch_transcriptData:
       description: |
         Channel containing the filtered transcript data from the simulated chromosome
-        Structure: [ val(meta), path(filtered_transcriptData) ]
+        Structure: [ val(meta), path(transcriptData) ]
       structure:
         - meta:
             type: map
             description: |
               Groovy Map containing sample information
               e.g. `[ id:'test', chromosome: 'chr22', coverage: 30, reps: 3, groups: 2, simthreshold: 0.3 ]`
-        - filtered_transcriptData:
+        - transcriptData:
             type: file
             description: RDS file containing filtered transcript data from the simulated chromosome
-            pattern: "filtered_transcriptData.rds"
+            pattern: "transcriptData.rds"
   - ch_genelists:
       description: |
         Channel containing those gene lists that should give an enrichment with EnrichGO

--- a/workflows/eduomics.nf
+++ b/workflows/eduomics.nf
@@ -150,7 +150,7 @@ workflow EDUOMICS {
         ch_rna_meta,
         ch_gff3,
         ch_txfasta,
-        SUBSET_REFERENCES_TO_TARGETS.out.target_fa.map { meta, fasta -> fasta }
+        ch_fasta
     )
 
     ch_versions = ch_versions.mix(PREPARE_RNA_GENOME.out.versions)

--- a/workflows/eduomics.nf
+++ b/workflows/eduomics.nf
@@ -157,7 +157,7 @@ workflow EDUOMICS {
 
     SIMULATE_RNASEQ_READS(
         PREPARE_RNA_GENOME.out.filtered_txfasta,
-        PREPARE_RNA_GENOME.out.filtered_transcript_data,
+        PREPARE_RNA_GENOME.out.transcript_data,
         PREPARE_RNA_GENOME.out.gene_lists,
         PREPARE_RNA_GENOME.out.gene_list_association
     )
@@ -176,7 +176,7 @@ workflow EDUOMICS {
         PREPARE_RNA_GENOME.out.filtered_txfasta,
         params.salmon_alignmode,
         params.salmon_libtype,
-        PREPARE_RNA_GENOME.out.filtered_transcript_data
+        PREPARE_RNA_GENOME.out.transcript_data
     )
 
     ch_versions = ch_versions.mix(QUANTIFY_DEANALYSIS_ENRICH_VALIDATE.out.versions)


### PR DESCRIPTION
PR to:
- Update the prepare_rna_genome subworkflow with samtools/faidx to subset the genome fasta with the simulated chromosome.
- Update the quantify_deanalysis_enrich_validate subworkflow --> in this part we addressed the issue with the input structure of the channel containing the simulated reads for Salmon Quant. The use of the `clone` for the meta is considered safer because it allows to work on a copy of the meta.

The 2 subworkflows work with:
- [x] nf-test test --profile conda
- [x] nf-test modules test --profile singularity
- [x]  nf-test modules test --profile docker