### PR TITLE
nasty issue with bash settings by nextflow

### DIFF
--- a/modules/local/dnavalidation/main.nf
+++ b/modules/local/dnavalidation/main.nf
@@ -27,11 +27,11 @@ process DNAVALIDATION {
 
     # check whether the variant position is present in the VCF
     if gzip -cd ${vcf} | grep -v '^#' | grep -q "\${variantpos}"; then
-        mkdir -p "${result_dir}"
-        echo "${variant}" > "${result_dir}/solution_${variant}.txt"
-        cp ${vcf} "${result_dir}/"
+        mkdir -p "\${result_dir}"
+        echo "${variant}" > "\${result_dir}/solution_${variant}.txt"
+        cp ${vcf} "\${result_dir}/"
         for read in ${reads}; do
-            cp "\$read" "${result_dir}/"
+            cp "\$read" "\${result_dir}/"
         done
     fi
 

--- a/modules/local/dnavalidation/main.nf
+++ b/modules/local/dnavalidation/main.nf
@@ -25,6 +25,11 @@ process DNAVALIDATION {
     variantpos=\$(cut -d"-" -f2 <<<"${variant}")
     result_dir="dna_${variant}_validation"
 
+    # Nextflow wrappers enable 'pipefail', causing this pipeline to exit with
+    # a non-zero status when `grep -q` stops reading early (SIGPIPE). Temporarily
+    # disable pipefail so the conditional evaluates correctly when the variant is
+    # found.
+    set +o pipefail
     # check whether the variant position is present in the VCF
     if gzip -cd ${vcf} | grep -v '^#' | grep -q "\$variantpos"; then
         mkdir -p "\$result_dir"
@@ -34,6 +39,7 @@ process DNAVALIDATION {
             cp "\$read" "\$result_dir/"
         done
     fi
+    set -o pipefail
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/dnavalidation/main.nf
+++ b/modules/local/dnavalidation/main.nf
@@ -46,7 +46,7 @@ process DNAVALIDATION {
     """
     mkdir -p dna_${variant}_validation
     touch dna_${variant}_validation/solution_${variant}.txt
-    touch dna_${variant}_validation/simulated_validated.vcf
+    touch dna_${variant}_validation/simulated_validated.vcf.gz
     for read in ${reads}; do
         touch dna_${variant}_validation/\$(basename \$read)
     done

--- a/modules/local/dnavalidation/main.nf
+++ b/modules/local/dnavalidation/main.nf
@@ -26,12 +26,12 @@ process DNAVALIDATION {
     result_dir="dna_${variant}_validation"
 
     # check whether the variant position is present in the VCF
-    if gzip -cd ${vcf} | grep -v '^#' | grep -q "\${variantpos}"; then
-        mkdir -p "\${result_dir}"
-        echo "${variant}" > "\${result_dir}/solution_${variant}.txt"
-        cp ${vcf} "\${result_dir}/"
+    if gzip -cd ${vcf} | grep -v '^#' | grep -q "\$variantpos"; then
+        mkdir -p "\$result_dir"
+        echo "${variant}" > "\$result_dir/solution_${variant}.txt"
+        cp ${vcf} "\$result_dir/"
         for read in ${reads}; do
-            cp "\$read" "\${result_dir}/"
+            cp "\$read" "\$result_dir/"
         done
     fi
 

--- a/modules/local/dnavalidation/tests/main.nf.test
+++ b/modules/local/dnavalidation/tests/main.nf.test
@@ -30,7 +30,7 @@ nextflow_process {
             assert process.success
             def dir = new File(process.out.dna_validated_results[0][1])
             def files = dir.listFiles() as List
-            assert files.count { it.name.endsWith('.vcf') } == 1
+            assert files.count { it.name.endsWith('.vcf.gz') } == 1
             assert files.count { it.name.endsWith('.txt') } == 1
             assert files.count { it.name.endsWith('.fastq.gz') } == 4
             assert files.size() == 6  // 1 solution file, 1 VCF, 4 FASTQ.GZ
@@ -70,7 +70,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test_stub', simulatedvar:'chr22-1234-A-T' ],
-                    file("dummy.vcf"),
+                    file("dummy.vcf.gz"),
                     [
                         file("dummy_case_1.fastq.gz"),
                         file("dummy_case_2.fastq.gz"),
@@ -86,7 +86,7 @@ nextflow_process {
             assert process.success
             def dir = new File(process.out.dna_validated_results[0][1])
             def files = dir.listFiles() as List
-            assert files.count { it.name.endsWith('.vcf') } == 1
+            assert files.count { it.name.endsWith('.vcf.gz') } == 1
             assert files.count { it.name.endsWith('.txt') } == 1
             assert files.count { it.name.endsWith('.fastq.gz') } == 4
             assert files.size() == 6  // 1 solution file, 1 VCF, 4 FASTQ.GZ

--- a/modules/local/dnavalidation/tests/main.nf.test
+++ b/modules/local/dnavalidation/tests/main.nf.test
@@ -13,8 +13,8 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test1', simulatedvar:'chr22-34449622-G-A' ],
-                    file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/result_ann_test.vcf"),
+                    [ id:'test1', simulatedvar:'chr22-18078510-T-C' ],
+                    file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/genotypeGVCFs/sim01.vcf.gz"),
                     [
                         file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_case_1.fastq.gz"),
                         file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_case_2.fastq.gz"),
@@ -44,7 +44,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test2', simulatedvar:'LOLLOLOLLO' ],
-                    file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/result_ann_test.vcf"),
+                    file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/genotypeGVCFs/sim01.vcf.gz"),
                     [
                         file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_case_1.fastq.gz"),
                         file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_case_2.fastq.gz"),

--- a/modules/local/dnavalidation/tests/main.nf.test
+++ b/modules/local/dnavalidation/tests/main.nf.test
@@ -13,8 +13,8 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test1', simulatedvar:'chr22-18078510-T-C' ],
-                    file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/genotypeGVCFs/sim01.vcf.gz"),
+                    [ id:'test1', simulatedvar:'chr22-17189980-T-C' ],
+                    file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/genotypeGVCFs/simulation1_chr22-17189980.vcf.gz"),
                     [
                         file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_case_1.fastq.gz"),
                         file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_case_2.fastq.gz"),
@@ -44,7 +44,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test2', simulatedvar:'LOLLOLOLLO' ],
-                    file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/genotypeGVCFs/sim01.vcf.gz"),
+                    file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/genotypeGVCFs/simulation1_chr22-17189980.vcf.gz"),
                     [
                         file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_case_1.fastq.gz"),
                         file("https://raw.githubusercontent.com/lescai-teaching/eduomics_testdata/refs/heads/main/dna/test1_case_2.fastq.gz"),


### PR DESCRIPTION
This issue has been fixed only by discovering that Nextflow wrappers enable 'pipefail', causing this pipeline to exit with a non-zero status when `grep -q` stops reading early (SIGPIPE)
To solve this we have to temporarily disable pipefail so the conditional evaluates correctly when the variant is found.