### PR TITLE
Fix the `No such variable: output` failure caused by nextflow new version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         NXF_VER:
-          - "25.04.3"
+          - "25.10.3"
           - "latest-everything"
         profile:
           - "conda"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Cite with Zenodo](http://img.shields.io/badge/DOI-10.5281/zenodo.15835070-1073c8?labelColor=000000)](https://doi.org/10.5281/zenodo.15835070)
 [![nf-test](https://img.shields.io/badge/unit_tests-nf--test-337ab7.svg)](https://www.nf-test.com)
 
-[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A525.04.3-23aa62.svg)](https://www.nextflow.io/)
+[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A525.10.0-23aa62.svg)](https://www.nextflow.io/)
 [![run with conda](http://img.shields.io/badge/run%20with-conda-3EB049?labelColor=000000&logo=anaconda)](https://docs.conda.io/en/latest/)
 [![run with docker](https://img.shields.io/badge/run%20with-docker-0db7ed?labelColor=000000&logo=docker)](https://www.docker.com/)
 [![run with singularity](https://img.shields.io/badge/run%20with-singularity-1d355c.svg?labelColor=000000)](https://sylabs.io/docs/)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,7 +13,7 @@ The eduomics pipeline is designed to create realistic, educational genomic datas
 
 Before running the pipeline, ensure you have:
 
-1. **Nextflow installed** (version ≥25.04.4)
+1. **Nextflow installed** (version ≥25.10.0)
 2. **Container system** (Docker, Singularity, or Conda)
 3. **Reference genome configured** (we recommend using `GATK.GRCh38`)
 

--- a/main.nf
+++ b/main.nf
@@ -15,8 +15,6 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-nextflow.preview.output = true
-
 include { EDUOMICS                     } from './workflows/eduomics'
 include { SUBSET_REFERENCES_TO_TARGETS } from './subworkflows/local/subset_references_to_targets'
 include { PREPARE_RNA_GENOME           } from './subworkflows/local/prepare_rna_genome'

--- a/nextflow.config
+++ b/nextflow.config
@@ -268,7 +268,7 @@ manifest {
     description     = """Simulation Pipeline for Educational Omics Data"""
     mainScript      = 'main.nf'
     defaultBranch   = 'master'
-    nextflowVersion = '!>=25.04.3' // this is needed to enable publish directive in current shape
+    nextflowVersion = '!>=25.10.0' // finalized workflow output syntax is required
     version         = '1.1.0'
     doi             = ''
 }


### PR DESCRIPTION
## Summary

This PR updates the pipeline to be compatible with the finalised workflow output syntax in modern Nextflow releases (tested with `25.10.3`).

## What changed

- Removed the obsolete preview toggle `nextflow.preview.output = true`.
- Kept/used the finalised workflow output model (`publish:` in the entry workflow + top-level `output {}` block).
- Bumped the minimum required Nextflow version to `>=25.10.0`.
- Updated documentation and badge to reflect the new minimum version.
- Updated the CI matrix minimum Nextflow version from `25.04.3` to `25.10.3` (while keeping `latest-everything`).

## Why

On Nextflow `25.10.3`, the old preview flag causes start-up failure with:

`ERROR ~ No such variable: output`

Removing the deprecated flag and aligning version requirements resolves this.

## Validation

Executed using the requested Conda environment:

- `conda run -n nf-core_3.5.2 nextflow -version`  
  → `25.10.3`
- `conda run -n nf-core_3.5.2 nextflow run main.nf -profile test,conda --outdir /tmp/eduomics-preview-25103 -preview -ansi-log false`  
  → Pipeline launched and completed successfully in preview mode.

## Impact

- No scientific/algorithmic workflow changes.
- This is a compatibility and maintenance update (runtime syntax, version constraints, documentation, and CI alignment).
